### PR TITLE
fix: App Distribution Gradle 플러그인 5.3.0 으로 올려 WIF 자격 파일을 읽게 한다

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ ktlint = "1.8.0"
 ktlintGradle = "12.1.1"
 composeRules = "0.5.6"
 screenshot = "0.0.1-alpha15"
-firebaseAppDistribution = "5.2.1"
+firebaseAppDistribution = "5.3.0"
 # --- 멀티모듈 DI ---
 hilt = "2.52"
 ksp = "2.0.21-1.0.28"


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #42

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- Firebase App Distribution Gradle 플러그인을 5.2.1 에서 5.3.0 으로 올렸다. main 머지 뒤 처음 돈 `release-distribution.yml` 이 WIF 인증과 attestation 검증을 통과한 뒤 `appDistributionUploadRelease` 에서 "Service credentials file does not exist" 로 멈췄다. google-github-actions/auth 가 만든 external_account 자격 파일과 `GOOGLE_APPLICATION_CREDENTIALS` 는 정상이었고, 같은 워크플로를 5.3.0 으로 쓰는 Afternote-FE 는 통과한다.
- 릴리스 노트: https://firebase.google.com/support/release-notes/android (App Distribution Gradle plugin 5.3.0). 좌표 `com.google.firebase:firebase-appdistribution-gradle:5.3.0`.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
UI 변경 없음.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 로컬에서는 `:app:appDistributionUploadRelease --dry-run` 으로 플러그인 설정만 확인했다. 실제 업로드는 이 PR 이 main 에 들어간 뒤 워크플로 실행으로 검증한다.
