### PR TITLE
chore: compileSdk·targetSdk 36 상향 (Play 신규 앱 API 36 요구)

### DIFF
--- a/Dockerfile.screenshot
+++ b/Dockerfile.screenshot
@@ -46,8 +46,8 @@ RUN mkdir -p "$ANDROID_HOME/cmdline-tools" \
 
 RUN yes | sdkmanager --licenses > /dev/null \
     && sdkmanager --install \
-        "platforms;android-35" \
-        "build-tools;35.0.0" \
+        "platforms;android-36" \
+        "build-tools;36.0.0" \
         "platform-tools" \
         > /dev/null
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,7 +34,7 @@ android {
     // namespace(R 클래스·소스 패키지)는 그대로 두고 applicationId 만 Play 등록용으로 바꾼다.
     // Play 는 com.example.* 패키지를 거부하며, Firebase Android 앱은 이 applicationId 로 등록돼 있다.
     namespace = "com.example.slowclock"
-    compileSdk = 35
+    compileSdk = 36
 
     // Compose Preview Screenshot Testing (alpha) 활성화
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
@@ -42,7 +42,7 @@ android {
     defaultConfig {
         applicationId = "com.ilhyok.slowclock"
         minSdk = 32
-        targetSdk = 35
+        targetSdk = 36
         versionCode = resolveSlowClockVersionCode(System.getenv(slowClockVersionCodeEnv))
         versionName = "1.0"
 

--- a/docs/play-release.md
+++ b/docs/play-release.md
@@ -21,6 +21,7 @@ Firebase App Distribution 과 Google Play 의 목적을 분리하고, 첫 Play �
 
 ## 출시 전 앱 상태 (#34 에서 정리)
 
+- · 는 36 이다(#45). Play 는 2026-08-31 부터 신규 앱과 업데이트에 Android 16(API 36) 타겟을 요구한다. 근거: [Google Play 의 타겟 API 수준 요구사항](https://developer.android.com/google/play/requirements/target-sdk). Android 16 동작 변경 중 이 앱에 닿는 것은 edge-to-edge 강제(이미  사용)와 predictive back 기본 활성화(Navigation Compose 사용,  미사용)뿐이다.
 - `applicationId` 는 `com.ilhyok.slowclock`. Firebase Android 앱과 `google-services.json` 도 이 패키지로 등록돼 있다.
 - Google 로그인 스코프는 `userinfo.profile`·`userinfo.email` 뿐이다. 민감 스코프(Calendar)를 빼서 OAuth 검증 심사 대상이 아니다.
 - 서비스 계정 키를 APK 에 내장하던 Vertex AI 경로는 제거됐다.


### PR DESCRIPTION
## 📌 Issues

Closes #45

## 📎 Work Description

- `app/build.gradle.kts` 의 `compileSdk`·`targetSdk` 를 35 에서 36 으로 올렸다. Google Play 는 2026-08-31 부터 신규 앱과 업데이트에 Android 16(API 36) 타겟을 요구하므로 개발자 계정을 만들기 전에 끝내야 하는 항목이다. 근거: https://developer.android.com/google/play/requirements/target-sdk
- `Dockerfile.screenshot` 이 설치하는 SDK 플랫폼과 build-tools 를 36 으로 맞췄다. 스크린샷 검증 컨테이너가 앱과 같은 API 로 컴파일한다.
- `docs/play-release.md` 에 API 36 요구와 Android 16 동작 변경 점검 결과를 적었다. 이 앱에 닿는 변경은 edge-to-edge 강제(이미 `enableEdgeToEdge()` 사용)와 predictive back 기본 활성화(Navigation Compose 사용, `onBackPressed` 미사용)뿐이라 코드 변경은 없다.

로컬 검증: `ktlintCheck`, `:app:assembleDebug`, `:app:assembleRelease`, `:app:bundleRelease`, `:app:lintDebug`, `:app:testDebugUnitTest` 통과. 릴리스 AAB 의 네이티브 라이브러리(`libandroidx.graphics.path.so`)는 16 KB 페이지 정렬(`p_align 0x4000`)을 만족한다.

## 📷 Screenshot

해당 없음 (빌드 설정 변경).

## 💬 To Reviewers

- 라이브러리 모듈(`core/*`, `feature/*`)의 `compileSdk` 는 35 그대로다. Play 요구는 앱의 `targetSdk` 이고, 모듈별 상향은 별도 작업으로 둔다.
- Screenshot 검사가 컨테이너 SDK 변경으로 baseline 과 달라지면 `screenshot-baseline` 라벨 흐름으로 갱신한다.