### PR TITLE
refactor: MainViewModel 을 화면별 MVI ViewModel 로 분해하고 일정을 Firestore 리스너로 받는다

### DIFF
--- a/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
@@ -16,17 +16,13 @@ import com.example.slowclock.ui.addschedule.AddScheduleScreen
 import com.example.slowclock.ui.common.components.BottomNavigationBar
 import com.example.slowclock.ui.done.DoneScreen
 import com.example.slowclock.ui.main.MainScreen
-import com.example.slowclock.ui.main.MainViewModel
 import com.example.slowclock.ui.profile.ProfileScreen
 import com.example.slowclock.ui.recommendation.RecommendationScreen
 import com.example.slowclock.ui.settings.SettingsScreen
 import com.example.slowclock.ui.timeline.TimelineScreen
 
 @Composable
-fun AppNavigation(
-    modifier: Modifier = Modifier,
-    mainViewModel: MainViewModel = hiltViewModel(),
-) {
+fun AppNavigation(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
     val currentRoute by navController.currentBackStackEntryFlow.collectAsState(
         initial = navController.currentBackStackEntry,
@@ -48,15 +44,7 @@ fun AppNavigation(
             modifier = Modifier.padding(innerPadding),
         ) {
             composable("main") {
-                val result =
-                    navController.currentBackStackEntry
-                        ?.savedStateHandle
-                        ?.get<Boolean>("schedule_added")
-
-                // 🔥 MainViewModel을 직접 전달
                 MainScreen(
-                    viewModel = mainViewModel, // 명시적으로 전달
-                    shouldRefresh = result == true,
                     onAddSchedule = {
                         navController.navigate("add_schedule")
                     },
@@ -69,20 +57,11 @@ fun AppNavigation(
                     onNavigateToSettings = {
                         navController.navigate("settings_share_code")
                     },
-                    onRefreshHandled = {
-                        navController.currentBackStackEntry
-                            ?.savedStateHandle
-                            ?.remove<Boolean>("schedule_added")
-                    },
                 )
             }
 
-            composable("done") {
-                DoneScreen(
-                    mainViewModel = mainViewModel,
-                )
-            }
-            composable("timeline") { TimelineScreen(mainViewModel) }
+            composable("done") { DoneScreen() }
+            composable("timeline") { TimelineScreen() }
             composable("settings") { SettingsScreen() }
 
             composable(
@@ -95,14 +74,7 @@ fun AppNavigation(
 
                 AddScheduleScreen(
                     initialTitle = initialTitle,
-                    onNavigateBack = { success ->
-                        if (success) {
-                            navController.previousBackStackEntry
-                                ?.savedStateHandle
-                                ?.set("schedule_added", true)
-                        }
-                        navController.popBackStack()
-                    },
+                    onNavigateBack = { navController.popBackStack() },
                     onNavigateToRecommendation = {
                         navController.navigate("recommendation")
                     },
@@ -113,16 +85,10 @@ fun AppNavigation(
                 val scheduleId = backStackEntry.arguments?.getString("scheduleId") ?: ""
                 AddScheduleScreen(
                     scheduleId = scheduleId,
-                    onNavigateBack = { success ->
-                        if (success) {
-                            navController.previousBackStackEntry
-                                ?.savedStateHandle
-                                ?.set("schedule_added", true)
-                        } else {
-                            navController.navigate("main") {
-                                popUpTo("main") { inclusive = false }
-                                launchSingleTop = true
-                            }
+                    onNavigateBack = {
+                        navController.navigate("main") {
+                            popUpTo("main") { inclusive = false }
+                            launchSingleTop = true
                         }
                     },
                     onNavigateToRecommendation = {

--- a/core/alarm/src/main/java/com/example/slowclock/notification/GuardianNotifier.kt
+++ b/core/alarm/src/main/java/com/example/slowclock/notification/GuardianNotifier.kt
@@ -2,59 +2,69 @@ package com.example.slowclock.notification
 
 import android.content.Context
 import android.util.Log
+import com.android.volley.RequestQueue
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.Volley
 import com.example.slowclock.data.notification.Notifier
+import dagger.hilt.android.qualifiers.ApplicationContext
 import org.json.JSONObject
-import java.lang.reflect.Method
+import javax.inject.Inject
+import javax.inject.Singleton
 
-object GuardianNotifier : Notifier {
-    // Replace with your deployed Cloud Function URL
-    private const val CLOUD_FUNCTION_URL = "https://us-central1-slow-clock-scheduler.cloudfunctions.net/sendFcmNotification"
+/** Cloud Function 을 통해 FCM 푸시를 보낸다. 앱 Context 로 Volley 큐를 하나만 유지한다. */
+@Singleton
+class GuardianNotifier
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) : Notifier {
+        private val requestQueue: RequestQueue by lazy { Volley.newRequestQueue(context) }
 
-    override fun sendReminderToUser(
-        context: Context,
-        fcmToken: String,
-        title: String,
-        message: String,
-        shareCode: String?,
-    ) {
-        val json =
-            JSONObject().apply {
-                put("token", fcmToken)
-                put("title", title)
-                put("body", message)
-                if (shareCode != null) {
-                    put("shareCode", shareCode)
+        override fun sendReminderToUser(
+            fcmToken: String,
+            title: String,
+            message: String,
+            shareCode: String?,
+        ) {
+            val json =
+                JSONObject().apply {
+                    put("token", fcmToken)
+                    put("title", title)
+                    put("body", message)
+                    if (shareCode != null) {
+                        put("shareCode", shareCode)
+                    }
                 }
+
+            val request =
+                object : JsonObjectRequest(
+                    Method.POST,
+                    CLOUD_FUNCTION_URL,
+                    json,
+                    { Log.d("FCM", "Push sent successfully via Cloud Function") },
+                    { error -> Log.e("FCM", "Push failed via Cloud Function", error) },
+                ) {
+                    override fun getHeaders(): MutableMap<String, String> =
+                        mutableMapOf(
+                            "Content-Type" to "application/json",
+                        )
+                }
+
+            requestQueue.add(request)
+        }
+
+        override fun sendReminderToUsers(
+            fcmTokens: List<String>,
+            title: String,
+            message: String,
+            shareCode: String?,
+        ) {
+            for (token in fcmTokens) {
+                sendReminderToUser(token, title, message, shareCode)
             }
+        }
 
-        val request =
-            object : JsonObjectRequest(
-                Method.POST,
-                CLOUD_FUNCTION_URL,
-                json,
-                { Log.d("FCM", "Push sent successfully via Cloud Function") },
-                { error -> Log.e("FCM", "Push failed via Cloud Function", error) },
-            ) {
-                override fun getHeaders(): MutableMap<String, String> =
-                    mutableMapOf(
-                        "Content-Type" to "application/json",
-                    )
-            }
-
-        Volley.newRequestQueue(context).add(request)
-    }
-
-    override fun sendReminderToUsers(
-        context: Context,
-        fcmTokens: List<String>,
-        title: String,
-        message: String,
-        shareCode: String?,
-    ) {
-        for (token in fcmTokens) {
-            sendReminderToUser(context, token, title, message, shareCode)
+        private companion object {
+            const val CLOUD_FUNCTION_URL = "https://us-central1-slow-clock-scheduler.cloudfunctions.net/sendFcmNotification"
         }
     }
-}

--- a/core/alarm/src/main/java/com/example/slowclock/notification/NotifierModule.kt
+++ b/core/alarm/src/main/java/com/example/slowclock/notification/NotifierModule.kt
@@ -1,8 +1,8 @@
 package com.example.slowclock.notification
 
 import com.example.slowclock.data.notification.Notifier
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 
@@ -13,7 +13,7 @@ import dagger.hilt.components.SingletonComponent
  */
 @Module
 @InstallIn(SingletonComponent::class)
-object NotifierModule {
-    @Provides
-    fun provideNotifier(): Notifier = GuardianNotifier
+abstract class NotifierModule {
+    @Binds
+    abstract fun bindNotifier(impl: GuardianNotifier): Notifier
 }

--- a/core/data/src/main/java/com/example/slowclock/data/notification/Notifier.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/notification/Notifier.kt
@@ -1,16 +1,14 @@
 package com.example.slowclock.data.notification
 
-import android.content.Context
-
 /**
  * 데이터 레이어가 알림 전송을 요청하기 위한 추상화.
  *
- * 구현체(GuardianNotifier)는 :core:alarm 에 있고,
- * Hilt 로 주입된다. 이로써 :core:data 가 :core:alarm 에 직접 의존하지 않는다(레이어 역전 제거).
+ * 구현체(GuardianNotifier)는 :core:alarm 에 있고 Hilt 로 주입된다. 이로써 :core:data 가
+ * :core:alarm 에 직접 의존하지 않는다. 구현체가 앱 Context 를 스스로 주입받으므로 호출자는
+ * Context 를 넘기지 않는다.
  */
 interface Notifier {
     fun sendReminderToUser(
-        context: Context,
         fcmToken: String,
         title: String,
         message: String,
@@ -18,7 +16,6 @@ interface Notifier {
     )
 
     fun sendReminderToUsers(
-        context: Context,
         fcmTokens: List<String>,
         title: String,
         message: String,

--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/FamilyGroupRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/FamilyGroupRepository.kt
@@ -1,6 +1,5 @@
 package com.example.slowclock.data.remote.repository
 
-import android.content.Context
 import com.example.slowclock.data.FirestoreCollections
 import com.example.slowclock.data.model.FamilyGroup
 import com.example.slowclock.data.notification.Notifier
@@ -156,7 +155,6 @@ class FamilyGroupRepository
 
         // 5. 그룹 전체에게 FCM 알림 발송
         suspend fun sendAlertToGroup(
-            context: Context,
             groupId: String,
             title: String,
             message: String,
@@ -164,7 +162,6 @@ class FamilyGroupRepository
             val tokens = fetchGroupMembersFcmTokens(groupId)
             tokens.forEach { token ->
                 notifier.sendReminderToUser(
-                    context = context,
                     fcmToken = token,
                     title = title,
                     message = message,

--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt
@@ -1,7 +1,6 @@
 // app/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt
 package com.example.slowclock.data.remote.repository
 
-import android.content.Context
 import android.util.Log
 import com.example.slowclock.data.FirestoreCollections
 import com.example.slowclock.data.model.Schedule
@@ -15,6 +14,7 @@ import com.google.firebase.firestore.FirebaseFirestoreException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.tasks.await
 import java.util.Calendar
 import javax.inject.Inject
@@ -402,6 +402,47 @@ class ScheduleRepository
             }
         }
 
+        // 특정 날짜의 일정 실시간 구독. 로그인 전이면 빈 목록을 한 번 내고 끝난다.
+        fun observeSchedulesForDate(calendar: Calendar): Flow<List<Schedule>> {
+            val uid = auth.currentUser?.uid ?: return flowOf(emptyList())
+            val startOfDay =
+                (calendar.clone() as Calendar).apply {
+                    set(Calendar.HOUR_OF_DAY, 0)
+                    set(Calendar.MINUTE, 0)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }
+            val endOfDay =
+                (calendar.clone() as Calendar).apply {
+                    set(Calendar.HOUR_OF_DAY, 23)
+                    set(Calendar.MINUTE, 59)
+                    set(Calendar.SECOND, 59)
+                    set(Calendar.MILLISECOND, 999)
+                }
+            return callbackFlow {
+                val listener =
+                    schedulesCollection
+                        .whereEqualTo("userId", uid)
+                        .addSnapshotListener { snapshot, error ->
+                            if (error != null) {
+                                close(error)
+                                return@addSnapshotListener
+                            }
+                            val schedules =
+                                snapshot
+                                    ?.documents
+                                    ?.mapNotNull { parseScheduleFromDocument(it) }
+                                    ?.filter { schedule ->
+                                        val time = schedule.startTime.toDate()
+                                        time.after(startOfDay.time) && time.before(endOfDay.time)
+                                    }?.sortedBy { it.startTime }
+                                    ?: emptyList()
+                            trySend(schedules)
+                        }
+                awaitClose { listener.remove() }
+            }
+        }
+
         // 공유 코드로 일정(리마인더) 목록 실시간 가져오기
         fun observeSchedulesBySharedCode(sharedCode: String): Flow<List<Schedule>> =
             callbackFlow {
@@ -424,7 +465,6 @@ class ScheduleRepository
 
         // 공유코드로 같은 그룹의 모든 사용자에게 FCM 알림 발송
         suspend fun sendNotificationToShareCodeMembers(
-            context: Context,
             shareCode: String,
             title: String,
             message: String,
@@ -441,7 +481,7 @@ class ScheduleRepository
                 val uid = userDoc.getString("id") ?: continue
                 if (uid == currentUid) continue // Skip self
                 val fcmToken = userDoc.getString("fcmToken") ?: continue
-                notifier.sendReminderToUser(context, fcmToken, title, message)
+                notifier.sendReminderToUser(fcmToken, title, message)
             }
 
             // Optimized: send to all tokens at once via Notifier
@@ -451,7 +491,7 @@ class ScheduleRepository
                     .mapNotNull { it.getString("fcmToken") }
                     .filter { it.isNotBlank() }
             if (tokens.isNotEmpty()) {
-                notifier.sendReminderToUsers(context, tokens, title, message)
+                notifier.sendReminderToUsers(tokens, title, message)
             }
         }
 
@@ -476,14 +516,13 @@ class ScheduleRepository
 
         // 🔔 여러 사용자에게 FCM 알림 전송
         suspend fun notifyShareCodeMembers(
-            context: Context,
             shareCode: String,
             title: String,
             message: String,
         ) {
             val tokens = getFcmTokensByShareCode(shareCode)
             if (tokens.isNotEmpty()) {
-                notifier.sendReminderToUsers(context, tokens, title, message)
+                notifier.sendReminderToUsers(tokens, title, message)
             }
         }
 

--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/SettingsRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/SettingsRepository.kt
@@ -1,0 +1,47 @@
+package com.example.slowclock.data.remote.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 기기에만 남는 사용자 설정. 지금은 공유 일정을 볼 공유 코드 하나다.
+ *
+ * 화면이 SharedPreferences 를 직접 읽지 않도록 여기로 모은다.
+ */
+@Singleton
+class SettingsRepository
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+    ) {
+        private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+        fun getShareCode(): String? = prefs.getString(KEY_SHARE_CODE, null)?.takeIf { it.isNotBlank() }
+
+        fun setShareCode(shareCode: String) {
+            prefs.edit().putString(KEY_SHARE_CODE, shareCode.trim()).apply()
+        }
+
+        /** 현재 값을 먼저 내고, 바뀔 때마다 다시 낸다. */
+        fun observeShareCode(): Flow<String?> =
+            callbackFlow {
+                val listener =
+                    SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+                        if (key == KEY_SHARE_CODE) trySend(getShareCode())
+                    }
+                prefs.registerOnSharedPreferenceChangeListener(listener)
+                trySend(getShareCode())
+                awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+            }
+
+        private companion object {
+            const val PREFS_NAME = "settings"
+            const val KEY_SHARE_CODE = "share_code"
+        }
+    }

--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/UserRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/UserRepository.kt
@@ -1,6 +1,5 @@
 package com.example.slowclock.data.remote.repository
 
-import android.content.Context
 import com.example.slowclock.data.FirestoreCollections
 import com.example.slowclock.data.model.User
 import com.example.slowclock.data.notification.Notifier
@@ -113,14 +112,10 @@ class UserRepository
                 }
         }
 
-        fun sendAlertToFamily(
-            context: Context,
-            groupId: String,
-        ) {
+        fun sendAlertToFamily(groupId: String) {
             fetchFamilyTokens(groupId) { tokens ->
                 tokens.forEach { token ->
                     notifier.sendReminderToUser(
-                        context = context,
                         fcmToken = token,
                         title = "가족 일정 알림",
                         message = "가족 그룹에서 새로운 알림이 도착했습니다.",

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -23,6 +23,10 @@ android {
     buildFeatures {
         compose = true
     }
+    testOptions {
+        // ViewModel 의 android.util.Log 호출이 JVM 단위 테스트에서 예외를 던지지 않도록 한다.
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -40,7 +44,7 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 
-    // MainViewModel(God-VM)이 직접 사용 — #26/#27 에서 정리 예정
-    implementation(libs.firebase.auth)
-    implementation(libs.firebase.messaging)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/feature/main/src/main/java/com/example/slowclock/ui/done/DoneContract.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/done/DoneContract.kt
@@ -1,0 +1,44 @@
+package com.example.slowclock.ui.done
+
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.ui.mvi.MviIntent
+import com.example.slowclock.ui.mvi.ReducerEvent
+import com.example.slowclock.ui.mvi.UiState
+import com.example.slowclock.util.AppError
+
+sealed interface DoneIntent : MviIntent {
+    data class ToggleComplete(
+        val scheduleId: String,
+    ) : DoneIntent
+
+    data object Retry : DoneIntent
+
+    data object ConsumeError : DoneIntent
+}
+
+data class DoneUiState(
+    val schedules: List<Schedule> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: AppError? = null,
+) : UiState {
+    val completed: List<Schedule> get() = schedules.filter { it.completed }
+    val remaining: List<Schedule> get() = schedules.filter { !it.completed }
+}
+
+sealed interface DoneReducerEvent : ReducerEvent {
+    data object Loading : DoneReducerEvent
+
+    data class Loaded(
+        val schedules: List<Schedule>,
+    ) : DoneReducerEvent
+
+    data class Failed(
+        val error: AppError,
+    ) : DoneReducerEvent
+
+    data class Toggled(
+        val scheduleId: String,
+    ) : DoneReducerEvent
+
+    data object ErrorConsumed : DoneReducerEvent
+}

--- a/feature/main/src/main/java/com/example/slowclock/ui/done/DoneScreen.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/done/DoneScreen.kt
@@ -1,4 +1,3 @@
-// app/src/main/java/com/example/slowclock/ui/done/DoneScreen.kt
 package com.example.slowclock.ui.done
 
 import androidx.compose.foundation.clickable
@@ -24,8 +23,8 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -34,25 +33,39 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.data.model.Schedule
-import com.example.slowclock.ui.main.MainViewModel
+import com.example.slowclock.ui.common.components.ErrorCard
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+/** 완료 화면(stateful). */
 @Composable
-fun DoneScreen(mainViewModel: MainViewModel) {
-    val uiState by mainViewModel.uiState.collectAsState()
+fun DoneScreen(
+    modifier: Modifier = Modifier,
+    viewModel: DoneViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    DoneContent(state = state, onIntent = viewModel::onIntent, modifier = modifier)
+}
 
-    val completed = uiState.todaySchedules.filter { it.completed }
-    val remaining = uiState.todaySchedules.filter { !it.completed }
-
-    val formatter = SimpleDateFormat("yyyy년 M월 d일 EEEE", Locale.KOREAN)
-    val timeFormatter = SimpleDateFormat("a h:mm", Locale.KOREAN)
+/** 완료 화면(stateless). 프리뷰·스크린샷 테스트 진입점이다. */
+@Composable
+internal fun DoneContent(
+    state: DoneUiState,
+    onIntent: (DoneIntent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val completed = state.completed
+    val remaining = state.remaining
+    val formatter = remember { SimpleDateFormat("yyyy년 M월 d일 EEEE", Locale.KOREAN) }
+    val timeFormatter = remember { SimpleDateFormat("a h:mm", Locale.KOREAN) }
 
     Column(
         modifier =
-            Modifier
+            modifier
                 .fillMaxSize()
                 .padding(16.dp)
                 .verticalScroll(rememberScrollState()),
@@ -74,6 +87,15 @@ fun DoneScreen(mainViewModel: MainViewModel) {
             textAlign = TextAlign.Center,
         )
 
+        state.error?.let { error ->
+            ErrorCard(
+                error = error,
+                canRetry = true,
+                onRetry = { onIntent(DoneIntent.Retry) },
+                onDismiss = { onIntent(DoneIntent.ConsumeError) },
+            )
+        }
+
         if (completed.isNotEmpty()) {
             Section(title = "완료한 일정", icon = Icons.Default.CheckCircle, color = Color(0xFF3A5CCC)) {
                 completed.forEach {
@@ -81,9 +103,7 @@ fun DoneScreen(mainViewModel: MainViewModel) {
                         schedule = it,
                         timeFormatter = timeFormatter,
                         completed = true,
-                        onClick = { schedule ->
-                            mainViewModel.toggleScheduleComplete(schedule.id)
-                        },
+                        onClick = { schedule -> onIntent(DoneIntent.ToggleComplete(schedule.id)) },
                     )
                 }
             }
@@ -96,9 +116,7 @@ fun DoneScreen(mainViewModel: MainViewModel) {
                         schedule = it,
                         timeFormatter = timeFormatter,
                         completed = false,
-                        onClick = { schedule ->
-                            mainViewModel.toggleScheduleComplete(schedule.id)
-                        },
+                        onClick = { schedule -> onIntent(DoneIntent.ToggleComplete(schedule.id)) },
                     )
                 }
             }
@@ -112,7 +130,6 @@ fun DoneScreen(mainViewModel: MainViewModel) {
             color = Color.DarkGray,
         )
 
-        // 🔥 수정된 LinearProgressIndicator
         LinearProgressIndicator(
             progress = {
                 if ((completed.size + remaining.size) == 0) {

--- a/feature/main/src/main/java/com/example/slowclock/ui/done/DoneViewModel.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/done/DoneViewModel.kt
@@ -1,0 +1,102 @@
+package com.example.slowclock.ui.done
+
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import com.example.slowclock.data.remote.repository.ScheduleRepository
+import com.example.slowclock.ui.mvi.MviViewModel
+import com.example.slowclock.util.toAppError
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import java.util.Calendar
+import javax.inject.Inject
+
+/** 완료 화면. 오늘 일정을 Firestore 리스너로 받아 완료·남은 일정으로 나눈다. */
+@HiltViewModel
+class DoneViewModel
+    @Inject
+    constructor(
+        private val scheduleRepository: ScheduleRepository,
+    ) : MviViewModel<DoneIntent, DoneUiState, DoneReducerEvent>(DoneUiState()) {
+        private var scheduleJob: Job? = null
+
+        init {
+            observeTodaySchedules()
+        }
+
+        override fun onIntent(intent: DoneIntent) {
+            when (intent) {
+                is DoneIntent.ToggleComplete -> {
+                    toggleComplete(intent.scheduleId)
+                }
+
+                DoneIntent.Retry -> {
+                    dispatch(DoneReducerEvent.ErrorConsumed)
+                    observeTodaySchedules()
+                }
+
+                DoneIntent.ConsumeError -> {
+                    dispatch(DoneReducerEvent.ErrorConsumed)
+                }
+            }
+        }
+
+        override fun reduce(
+            state: DoneUiState,
+            event: DoneReducerEvent,
+        ): DoneUiState =
+            when (event) {
+                DoneReducerEvent.Loading -> {
+                    state.copy(isLoading = true, error = null)
+                }
+
+                is DoneReducerEvent.Loaded -> {
+                    state.copy(schedules = event.schedules, isLoading = false, error = null)
+                }
+
+                is DoneReducerEvent.Failed -> {
+                    state.copy(isLoading = false, error = event.error)
+                }
+
+                is DoneReducerEvent.Toggled -> {
+                    state.copy(
+                        schedules = state.schedules.map { if (it.id == event.scheduleId) it.copy(completed = !it.completed) else it },
+                    )
+                }
+
+                DoneReducerEvent.ErrorConsumed -> {
+                    state.copy(error = null)
+                }
+            }
+
+        private fun observeTodaySchedules() {
+            scheduleJob?.cancel()
+            scheduleJob =
+                viewModelScope.launch {
+                    dispatch(DoneReducerEvent.Loading)
+                    scheduleRepository
+                        .observeSchedulesForDate(Calendar.getInstance())
+                        .catch { e ->
+                            Log.e(TAG, "일정 구독 실패", e)
+                            dispatch(DoneReducerEvent.Failed(e.toAppError()))
+                        }.collect { dispatch(DoneReducerEvent.Loaded(it)) }
+                }
+        }
+
+        private fun toggleComplete(scheduleId: String) {
+            val schedule = currentState.schedules.find { it.id == scheduleId } ?: return
+            dispatch(DoneReducerEvent.Toggled(scheduleId))
+            viewModelScope.launch {
+                val result = scheduleRepository.markScheduleAsCompleted(scheduleId, !schedule.completed)
+                if (result is ScheduleRepository.ScheduleResult.Error) {
+                    Log.e(TAG, "완료 상태 변경 실패: ${result.error.message}")
+                    dispatch(DoneReducerEvent.Failed(result.error))
+                }
+            }
+        }
+
+        private companion object {
+            const val TAG = "DoneViewModel"
+        }
+    }

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainContract.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainContract.kt
@@ -1,0 +1,111 @@
+package com.example.slowclock.ui.main
+
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.ui.mvi.MviIntent
+import com.example.slowclock.ui.mvi.ReducerEvent
+import com.example.slowclock.ui.mvi.UiState
+import com.example.slowclock.util.AppError
+
+/** 메인 화면에서 사용자가 하려는 것. */
+sealed interface MainIntent : MviIntent {
+    data object Retry : MainIntent
+
+    data class ToggleComplete(
+        val scheduleId: String,
+    ) : MainIntent
+
+    data class ShowDetail(
+        val scheduleId: String,
+    ) : MainIntent
+
+    data object HideDetail : MainIntent
+
+    data class RequestDelete(
+        val scheduleId: String,
+    ) : MainIntent
+
+    data object DismissDelete : MainIntent
+
+    data object ConfirmDelete : MainIntent
+
+    data class ToggleSharedReminderComplete(
+        val scheduleId: String,
+    ) : MainIntent
+
+    data object ConsumeError : MainIntent
+}
+
+/** 메인 화면의 단일 UI 상태. 오늘 일정과 공유 일정, 다이얼로그 상태를 담는다. */
+data class MainUiState(
+    val todaySchedules: List<Schedule> = emptyList(),
+    val sharedReminders: List<Schedule> = emptyList(),
+    val sharedReminderOwners: Map<String, String> = emptyMap(),
+    val currentSchedule: Schedule? = null,
+    val completedCount: Int = 0,
+    val totalCount: Int = 0,
+    val isLoading: Boolean = false,
+    val error: AppError? = null,
+    val canRetry: Boolean = false,
+    val selectedScheduleForDetail: Schedule? = null,
+    /** null 이 아니면 삭제 확인 다이얼로그가 떠 있다. */
+    val scheduleToDelete: Schedule? = null,
+    val currentUserId: String = "",
+) : UiState
+
+/** 메인 화면의 상태가 겪은 것. 화면은 만들지 않고 ViewModel 만 dispatch 한다. */
+sealed interface MainReducerEvent : ReducerEvent {
+    data class UserResolved(
+        val userId: String,
+    ) : MainReducerEvent
+
+    data object Loading : MainReducerEvent
+
+    /** [nowMillis] 는 「지금 할 일」 계산에만 쓴다. reduce 가 시계를 읽지 않도록 밖에서 넣는다. */
+    data class SchedulesLoaded(
+        val schedules: List<Schedule>,
+        val nowMillis: Long,
+    ) : MainReducerEvent
+
+    data class LoadFailed(
+        val error: AppError,
+        val canRetry: Boolean,
+    ) : MainReducerEvent
+
+    data class CompletionToggled(
+        val scheduleId: String,
+        val nowMillis: Long,
+    ) : MainReducerEvent
+
+    data class DetailShown(
+        val schedule: Schedule,
+    ) : MainReducerEvent
+
+    data object DetailHidden : MainReducerEvent
+
+    data class DeleteRequested(
+        val schedule: Schedule,
+    ) : MainReducerEvent
+
+    data object DeleteDismissed : MainReducerEvent
+
+    data object Deleting : MainReducerEvent
+
+    data class Deleted(
+        val scheduleId: String,
+        val nowMillis: Long,
+    ) : MainReducerEvent
+
+    data class SharedRemindersLoaded(
+        val reminders: List<Schedule>,
+    ) : MainReducerEvent
+
+    data class SharedReminderOwnersLoaded(
+        val owners: Map<String, String>,
+    ) : MainReducerEvent
+
+    data class SharedReminderToggled(
+        val scheduleId: String,
+    ) : MainReducerEvent
+
+    data object ErrorConsumed : MainReducerEvent
+}

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainScheduleSelector.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainScheduleSelector.kt
@@ -1,0 +1,33 @@
+package com.example.slowclock.ui.main
+
+import com.example.slowclock.data.model.Schedule
+
+private const val DEFAULT_DURATION_MILLIS = 60 * 60 * 1000L
+
+private fun Schedule.endMillis(): Long = endTime?.toDate()?.time ?: (startTime.toDate().time + DEFAULT_DURATION_MILLIS)
+
+/**
+ * 「지금 할 일」 하나를 고른다. 순수 함수라 리듀서 안에서 부른다.
+ *
+ * 1. 진행 중인 일정이 있으면 그중 끝나는 시각이 가장 빠른 것
+ * 2. 없으면 아직 시작하지 않은 일정 중 시작 시각이 가장 빠른 것(같으면 끝나는 시각이 빠른 것)
+ * 완료한 일정은 후보에서 뺀다.
+ */
+internal fun selectCurrentSchedule(
+    schedules: List<Schedule>,
+    nowMillis: Long,
+): Schedule? {
+    val incomplete = schedules.filter { !it.completed }
+    val ongoing =
+        incomplete.filter { schedule ->
+            val start = schedule.startTime.toDate().time
+            nowMillis >= start && nowMillis <= schedule.endMillis()
+        }
+    if (ongoing.isNotEmpty()) {
+        return ongoing.minByOrNull { it.endMillis() }
+    }
+    return incomplete
+        .filter { it.startTime.toDate().time > nowMillis }
+        .sortedWith(compareBy<Schedule> { it.startTime.toDate().time }.thenBy { it.endMillis() })
+        .firstOrNull()
+}

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainScreen.kt
@@ -1,4 +1,3 @@
-// app/src/main/java/com/example/slowclock/ui/main/MainScreen.kt
 package com.example.slowclock.ui.main
 
 import androidx.compose.foundation.background
@@ -23,22 +22,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.ui.common.components.ErrorCard
 import com.example.slowclock.ui.common.dialog.DeleteConfirmDialog
 import com.example.slowclock.ui.main.components.CurrentTaskSection
@@ -47,110 +37,99 @@ import com.example.slowclock.ui.main.components.ScheduleDetailDialog
 import com.example.slowclock.ui.main.components.SharedRemindersSection
 import com.example.slowclock.ui.main.components.TodayScheduleSection
 import java.text.SimpleDateFormat
-import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 
-@OptIn(ExperimentalMaterial3Api::class)
+/** 메인 화면(stateful). 네비게이션 콜백만 받고 나머지는 [MainIntent] 로 보낸다. */
 @Composable
 fun MainScreen(
-    viewModel: MainViewModel,
-    shouldRefresh: Boolean = false,
-    onAddSchedule: () -> Unit = {},
-    onEditSchedule: (String) -> Unit = {},
-    onNavigateToProfile: () -> Unit = {},
-    onNavigateToSettings: () -> Unit = {},
-    onRefreshHandled: () -> Unit = {},
+    onAddSchedule: () -> Unit,
+    onEditSchedule: (String) -> Unit,
+    onNavigateToProfile: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-    val dateFormat = SimpleDateFormat("yyyy년 M월 d일 EEEE", Locale.KOREAN)
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    MainContent(
+        state = state,
+        onIntent = viewModel::onIntent,
+        onAddSchedule = onAddSchedule,
+        onEditSchedule = onEditSchedule,
+        onNavigateToProfile = onNavigateToProfile,
+        onNavigateToSettings = onNavigateToSettings,
+        modifier = modifier,
+    )
+}
+
+/** 메인 화면(stateless). 프리뷰·스크린샷 테스트 진입점이다. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun MainContent(
+    state: MainUiState,
+    onIntent: (MainIntent) -> Unit,
+    onAddSchedule: () -> Unit,
+    onEditSchedule: (String) -> Unit,
+    onNavigateToProfile: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dateFormat = remember { SimpleDateFormat("yyyy년 M월 d일 EEEE", Locale.KOREAN) }
     val timeFormat = remember { SimpleDateFormat("HH:mm", Locale.getDefault()) }
-    val context = LocalContext.current
-    var lastShareCode by remember { mutableStateOf("") }
-    val prefs = remember { context.getSharedPreferences("settings", android.content.Context.MODE_PRIVATE) }
-    val shareCode = prefs.getString("share_code", null)
-    val currentUserUid = uiState.currentUserId.ifBlank { null }
 
-    val calendar = Calendar.getInstance()
-    // 일정 추가 후 자동 새로고침
-    LaunchedEffect(shouldRefresh) {
-        if (shouldRefresh) {
-            viewModel.loadSchedules(calendar)
-            val shareCode = prefs.getString("share_code", null)
-            if (!shareCode.isNullOrBlank()) {
-                viewModel.observeSharedReminders(shareCode)
-            }
-            onRefreshHandled()
-        }
-    }
-
-    // 세부정보 다이얼로그
-    uiState.selectedScheduleForDetail?.let { schedule ->
+    state.selectedScheduleForDetail?.let { schedule ->
         ScheduleDetailDialog(
             schedule = schedule,
-            onDismiss = { viewModel.hideScheduleDetail() },
+            onDismiss = { onIntent(MainIntent.HideDetail) },
             onEdit = {
-                viewModel.hideScheduleDetail()
+                onIntent(MainIntent.HideDetail)
                 onEditSchedule(schedule.id)
             },
             onDelete = {
-                viewModel.hideScheduleDetail()
-                viewModel.showDeleteConfirmDialog(schedule.id)
+                onIntent(MainIntent.HideDetail)
+                onIntent(MainIntent.RequestDelete(schedule.id))
             },
         )
     }
 
-    // 삭제 확인 다이얼로그 (이것도 필요함)
-    if (uiState.showDeleteConfirmDialog && uiState.scheduleToDelete != null) {
+    state.scheduleToDelete?.let { schedule ->
         DeleteConfirmDialog(
-            schedule = uiState.scheduleToDelete!!,
-            onConfirm = {
-                viewModel.deleteSchedule(uiState.scheduleToDelete!!.id)
-            },
-            onDismiss = { viewModel.hideDeleteConfirmDialog() },
+            schedule = schedule,
+            onConfirm = { onIntent(MainIntent.ConfirmDelete) },
+            onDismiss = { onIntent(MainIntent.DismissDelete) },
         )
-    }
-
-    LaunchedEffect(shareCode) {
-        if (!shareCode.isNullOrBlank() && shareCode != lastShareCode) {
-            lastShareCode = shareCode
-            viewModel.observeSharedReminders(shareCode)
-        }
     }
 
     Scaffold(
+        modifier = modifier,
         topBar = {
             CenterAlignedTopAppBar(
                 title = {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(
                             text = "느린시계",
-                            style = MaterialTheme.typography.headlineLarge, // fontSize 대신 style 사용
-                            color = MaterialTheme.colorScheme.primary, // 하드코딩 색상 제거
+                            style = MaterialTheme.typography.headlineLarge,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                         Text(
                             text = dateFormat.format(Date()),
-                            style = MaterialTheme.typography.bodyLarge, // fontSize 대신 style 사용
-                            color = MaterialTheme.colorScheme.onSurfaceVariant, // 하드코딩 색상 제거
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 },
                 actions = {
-                    // 프로필 버튼 (더 크게)
                     IconButton(
                         onClick = onNavigateToProfile,
-                        modifier = Modifier.size(56.dp), // 48dp → 56dp
+                        modifier = Modifier.size(56.dp),
                     ) {
                         Icon(
                             Icons.Default.Person,
                             contentDescription = "내 정보",
-                            tint = MaterialTheme.colorScheme.primary, // 하드코딩 색상 제거
-                            modifier = Modifier.size(32.dp), // 28dp → 32dp
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(32.dp),
                         )
                     }
-                    // 설정(share code) 버튼
                     IconButton(
                         onClick = onNavigateToSettings,
                         modifier = Modifier.size(56.dp),
@@ -165,21 +144,21 @@ fun MainScreen(
                 },
                 colors =
                     TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface, // 하드코딩 색상 제거
+                        containerColor = MaterialTheme.colorScheme.surface,
                     ),
             )
         },
         floatingActionButton = {
             FloatingActionButton(
                 onClick = onAddSchedule,
-                containerColor = MaterialTheme.colorScheme.primary, // 하드코딩 색상 제거
-                modifier = Modifier.size(72.dp), // 64dp → 72dp
+                containerColor = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(72.dp),
             ) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = "일정 추가",
-                    tint = MaterialTheme.colorScheme.onPrimary, // 하드코딩 색상 제거
-                    modifier = Modifier.size(36.dp), // 32dp → 36dp
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(36.dp),
                 )
             }
         },
@@ -190,58 +169,48 @@ fun MainScreen(
                     .fillMaxSize()
                     .padding(paddingValues)
                     .background(MaterialTheme.colorScheme.background),
-            // 하드코딩 색상 제거
-            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp), // 더 큰 패딩
-            verticalArrangement = Arrangement.spacedBy(24.dp), // 더 큰 간격
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
         ) {
-            // 🟡 지금 할 일
-            uiState.currentSchedule?.let { schedule ->
+            state.currentSchedule?.let { schedule ->
                 item {
                     CurrentTaskSection(
                         schedule = schedule,
-                        onShowDetail = { viewModel.showScheduleDetail(schedule.id) },
+                        onShowDetail = { onIntent(MainIntent.ShowDetail(schedule.id)) },
                     )
                 }
             }
 
-            // 📋 오늘의 일정
             item {
                 TodayScheduleSection(
-                    schedules = uiState.todaySchedules,
-                    onToggleComplete = viewModel::toggleScheduleComplete,
-                    onShowDetail = viewModel::showScheduleDetail,
+                    schedules = state.todaySchedules,
+                    onToggleComplete = { onIntent(MainIntent.ToggleComplete(it)) },
+                    onShowDetail = { onIntent(MainIntent.ShowDetail(it)) },
                 )
             }
 
-            // Shared Reminders Section
-            if (uiState.sharedReminders.isNotEmpty()) {
+            if (state.sharedReminders.isNotEmpty()) {
                 item {
                     SharedRemindersSection(
-                        sharedReminders = uiState.sharedReminders,
-                        currentUserUid = currentUserUid,
+                        sharedReminders = state.sharedReminders,
+                        currentUserUid = state.currentUserId.ifBlank { null },
                         timeFormat = timeFormat,
-                        onToggleComplete = { scheduleId ->
-                            viewModel.toggleSharedReminderComplete(scheduleId, context)
-                        },
+                        onToggleComplete = { onIntent(MainIntent.ToggleSharedReminderComplete(it)) },
                     )
                 }
             }
 
-            // 빈 상태 처리
-            if (uiState.todaySchedules.isEmpty() && !uiState.isLoading) {
-                item {
-                    EmptyStateCard()
-                }
+            if (state.todaySchedules.isEmpty() && !state.isLoading) {
+                item { EmptyStateCard() }
             }
 
-            // 에러 메시지
-            if (uiState.error != null) {
+            state.error?.let { error ->
                 item {
                     ErrorCard(
-                        error = uiState.error!!,
-                        canRetry = uiState.canRetry,
-                        onRetry = { viewModel.retryLastAction() },
-                        onDismiss = { viewModel.clearError() },
+                        error = error,
+                        canRetry = state.canRetry,
+                        onRetry = { onIntent(MainIntent.Retry) },
+                        onDismiss = { onIntent(MainIntent.ConsumeError) },
                     )
                 }
             }

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainViewModel.kt
@@ -1,41 +1,31 @@
-// app/src/main/java/com/example/slowclock/ui/main/MainViewModel.kt
 package com.example.slowclock.ui.main
 
-import android.content.Context
 import android.util.Log
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.slowclock.data.model.Schedule
 import com.example.slowclock.data.remote.repository.AuthRepository
 import com.example.slowclock.data.remote.repository.ScheduleRepository
+import com.example.slowclock.data.remote.repository.SettingsRepository
 import com.example.slowclock.data.remote.repository.UserRepository
-import com.example.slowclock.util.AppError
+import com.example.slowclock.ui.mvi.MviViewModel
+import com.example.slowclock.util.toAppError
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import java.util.Calendar
+import java.util.Date
 import javax.inject.Inject
 
-data class MainUiState(
-    val todaySchedules: List<Schedule> = emptyList(),
-    val sharedReminders: List<Schedule> = emptyList(), // 공유 일정
-    val currentSchedule: Schedule? = null,
-    val completedCount: Int = 0,
-    val totalCount: Int = 0,
-    val isLoading: Boolean = false,
-    val error: AppError? = null, // String → AppError 변경
-    val selectedScheduleForDetail: Schedule? = null,
-    val canRetry: Boolean = false, // 재시도 가능 여부 추가
-    val showDeleteConfirmDialog: Boolean = false,
-    val scheduleToDelete: Schedule? = null,
-    val sharedReminderOwners: Map<String, String> = emptyMap(), // userId -> name
-    val currentUserId: String = "",
-)
-
+/**
+ * 메인 화면. 오늘 일정은 Firestore 리스너로 받는다. 완료 토글·삭제는 낙관적으로 먼저 반영하고,
+ * 실패하면 리스너가 서버 상태로 되돌린다. 공유 일정은 기기에 저장된 공유 코드가 바뀔 때마다
+ * 다시 구독한다.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class MainViewModel
     @Inject
@@ -43,386 +33,246 @@ class MainViewModel
         private val scheduleRepository: ScheduleRepository,
         private val userRepository: UserRepository,
         private val authRepository: AuthRepository,
-    ) : ViewModel() {
-        private var sharedRemindersJob: Job? = null
-
-        private val _uiState = MutableStateFlow(MainUiState())
-        val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
+        private val settingsRepository: SettingsRepository,
+    ) : MviViewModel<MainIntent, MainUiState, MainReducerEvent>(MainUiState()) {
+        private var scheduleJob: Job? = null
 
         init {
-            _uiState.value = _uiState.value.copy(currentUserId = authRepository.currentUid.orEmpty())
-            loadSchedules(Calendar.getInstance())
+            dispatch(MainReducerEvent.UserResolved(authRepository.currentUid.orEmpty()))
+            observeTodaySchedules()
+            observeSharedReminders()
         }
 
-        fun loadSchedules(calendar: Calendar) {
-            val scheduleDate = calendar.clone() as Calendar
-            scheduleDate.set(Calendar.HOUR_OF_DAY, 0)
-            scheduleDate.set(Calendar.MINUTE, 0)
-            scheduleDate.set(Calendar.SECOND, 0)
-            scheduleDate.set(Calendar.MILLISECOND, 0)
-            viewModelScope.launch {
-                _uiState.value =
-                    _uiState.value.copy(
-                        isLoading = true,
-                        error = null,
-                        canRetry = false,
-                    )
+        override fun onIntent(intent: MainIntent) {
+            when (intent) {
+                MainIntent.Retry -> {
+                    dispatch(MainReducerEvent.ErrorConsumed)
+                    observeTodaySchedules()
+                }
 
-                try {
-                    when (val result = scheduleRepository.getSchedulesForDate(scheduleDate)) {
-                        is ScheduleRepository.ScheduleResult.Success -> {
-                            val schedules = result.data
-                            val currentTime = System.currentTimeMillis()
+                is MainIntent.ToggleComplete -> {
+                    toggleComplete(intent.scheduleId)
+                }
 
-                            val currentSchedule =
-                                schedules
-                                    .filter { !it.completed }
-                                    .let { incompleteSchedules ->
-                                        // 1단계: 현재 진행 중인 일정들
-                                        val ongoingSchedules =
-                                            incompleteSchedules.filter { schedule ->
-                                                val startTime = schedule.startTime.toDate().time
-                                                val endTime =
-                                                    schedule.endTime?.toDate()?.time
-                                                        ?: (startTime + 60 * 60 * 1000)
-                                                currentTime >= startTime && currentTime <= endTime
-                                            }
+                is MainIntent.ShowDetail -> {
+                    currentState.todaySchedules
+                        .find { it.id == intent.scheduleId }
+                        ?.let { dispatch(MainReducerEvent.DetailShown(it)) }
+                }
 
-                                        if (ongoingSchedules.isNotEmpty()) {
-                                            // 진행 중: 끝나는 시간 빠른 순
-                                            ongoingSchedules.minByOrNull { schedule ->
-                                                schedule.endTime?.toDate()?.time
-                                                    ?: (schedule.startTime.toDate().time + 60 * 60 * 1000)
-                                            }
-                                        } else {
-                                            // 진행 중 없음: 시작 시간 빠른 순 → 끝나는 시간 빠른 순
-                                            incompleteSchedules
-                                                .filter { it.startTime.toDate().time > currentTime }
-                                                .sortedWith(
-                                                    compareBy<Schedule> { it.startTime.toDate().time }
-                                                        .thenBy { schedule ->
-                                                            schedule.endTime?.toDate()?.time
-                                                                ?: (schedule.startTime.toDate().time + 60 * 60 * 1000)
-                                                        },
-                                                ).firstOrNull()
-                                        }
-                                    }
+                MainIntent.HideDetail -> {
+                    dispatch(MainReducerEvent.DetailHidden)
+                }
 
-                            _uiState.value =
-                                MainUiState(
-                                    todaySchedules = schedules,
-                                    currentSchedule = currentSchedule,
-                                    completedCount = schedules.count { it.completed },
-                                    totalCount = schedules.size,
-                                    isLoading = false,
-                                )
+                is MainIntent.RequestDelete -> {
+                    currentState.todaySchedules
+                        .find { it.id == intent.scheduleId }
+                        ?.let { dispatch(MainReducerEvent.DeleteRequested(it)) }
+                }
 
-                            Log.d("MainViewModel", "일정 로드 성공: ${schedules.size}개")
-                        }
+                MainIntent.DismissDelete -> {
+                    dispatch(MainReducerEvent.DeleteDismissed)
+                }
 
-                        is ScheduleRepository.ScheduleResult.Error -> {
-                            Log.e("MainViewModel", "일정 로드 실패: ${result.error.message}")
-                            _uiState.value =
-                                _uiState.value.copy(
-                                    isLoading = false,
-                                    error = result.error,
-                                    canRetry = true, // 재시도 가능
-                                )
-                        }
-                    }
-                } catch (e: Exception) {
-                    Log.e("MainViewModel", "예상치 못한 에러", e)
-                    _uiState.value =
-                        _uiState.value.copy(
-                            isLoading = false,
-                            error = AppError.GeneralError("일정을 불러오는 중 문제가 발생했습니다"),
-                            canRetry = true,
-                        )
+                MainIntent.ConfirmDelete -> {
+                    deleteSchedule()
+                }
+
+                is MainIntent.ToggleSharedReminderComplete -> {
+                    toggleSharedReminderComplete(intent.scheduleId)
+                }
+
+                MainIntent.ConsumeError -> {
+                    dispatch(MainReducerEvent.ErrorConsumed)
                 }
             }
         }
 
-        fun toggleScheduleComplete(scheduleId: String) {
+        override fun reduce(
+            state: MainUiState,
+            event: MainReducerEvent,
+        ): MainUiState =
+            when (event) {
+                is MainReducerEvent.UserResolved -> {
+                    state.copy(currentUserId = event.userId)
+                }
+
+                MainReducerEvent.Loading -> {
+                    state.copy(isLoading = true, error = null, canRetry = false)
+                }
+
+                is MainReducerEvent.SchedulesLoaded -> {
+                    state.withSchedules(event.schedules, event.nowMillis).copy(isLoading = false, error = null)
+                }
+
+                is MainReducerEvent.LoadFailed -> {
+                    state.copy(isLoading = false, error = event.error, canRetry = event.canRetry)
+                }
+
+                is MainReducerEvent.CompletionToggled -> {
+                    state.withSchedules(
+                        state.todaySchedules.map { if (it.id == event.scheduleId) it.copy(completed = !it.completed) else it },
+                        event.nowMillis,
+                    )
+                }
+
+                is MainReducerEvent.DetailShown -> {
+                    state.copy(selectedScheduleForDetail = event.schedule)
+                }
+
+                MainReducerEvent.DetailHidden -> {
+                    state.copy(selectedScheduleForDetail = null)
+                }
+
+                is MainReducerEvent.DeleteRequested -> {
+                    state.copy(scheduleToDelete = event.schedule)
+                }
+
+                MainReducerEvent.DeleteDismissed -> {
+                    state.copy(scheduleToDelete = null)
+                }
+
+                MainReducerEvent.Deleting -> {
+                    state.copy(isLoading = true, error = null, scheduleToDelete = null)
+                }
+
+                is MainReducerEvent.Deleted -> {
+                    state
+                        .withSchedules(state.todaySchedules.filter { it.id != event.scheduleId }, event.nowMillis)
+                        .copy(isLoading = false)
+                }
+
+                is MainReducerEvent.SharedRemindersLoaded -> {
+                    state.copy(sharedReminders = event.reminders)
+                }
+
+                is MainReducerEvent.SharedReminderOwnersLoaded -> {
+                    state.copy(sharedReminderOwners = event.owners)
+                }
+
+                is MainReducerEvent.SharedReminderToggled -> {
+                    state.copy(
+                        sharedReminders =
+                            state.sharedReminders.map {
+                                if (it.id == event.scheduleId) it.copy(completed = !it.completed) else it
+                            },
+                    )
+                }
+
+                MainReducerEvent.ErrorConsumed -> {
+                    state.copy(error = null, canRetry = false)
+                }
+            }
+
+        private fun MainUiState.withSchedules(
+            schedules: List<Schedule>,
+            nowMillis: Long,
+        ): MainUiState =
+            copy(
+                todaySchedules = schedules,
+                currentSchedule = selectCurrentSchedule(schedules, nowMillis),
+                completedCount = schedules.count { it.completed },
+                totalCount = schedules.size,
+            )
+
+        private fun observeTodaySchedules() {
+            scheduleJob?.cancel()
+            scheduleJob =
+                viewModelScope.launch {
+                    dispatch(MainReducerEvent.Loading)
+                    scheduleRepository
+                        .observeSchedulesForDate(Calendar.getInstance())
+                        .catch { e ->
+                            Log.e(TAG, "일정 구독 실패", e)
+                            dispatch(MainReducerEvent.LoadFailed(e.toAppError(), canRetry = true))
+                        }.collect { schedules ->
+                            dispatch(MainReducerEvent.SchedulesLoaded(schedules, System.currentTimeMillis()))
+                        }
+                }
+        }
+
+        private fun observeSharedReminders() {
             viewModelScope.launch {
-                val schedule = _uiState.value.todaySchedules.find { it.id == scheduleId }
-                schedule?.let {
-                    // 낙관적 업데이트 (즉시 UI 변경)
-                    val updatedSchedules =
-                        _uiState.value.todaySchedules.map { s ->
-                            if (s.id == scheduleId) s.copy(completed = !s.completed) else s
+                settingsRepository
+                    .observeShareCode()
+                    .flatMapLatest { shareCode ->
+                        if (shareCode.isNullOrBlank()) {
+                            flowOf(emptyList())
+                        } else {
+                            scheduleRepository.observeSchedulesBySharedCode(shareCode).catch { e ->
+                                Log.e(TAG, "공유 일정 구독 실패", e)
+                                emit(emptyList())
+                            }
                         }
-
-                    val currentTime = System.currentTimeMillis()
-                    val currentSchedule =
-                        updatedSchedules.firstOrNull { schedule ->
-                            !schedule.completed &&
-                                schedule.startTime.toDate().time <= currentTime &&
-                                (schedule.endTime?.toDate()?.time ?: Long.MAX_VALUE) > currentTime
-                        }
-
-                    _uiState.value =
-                        _uiState.value.copy(
-                            todaySchedules = updatedSchedules,
-                            currentSchedule = currentSchedule,
-                            completedCount = updatedSchedules.count { it.completed },
-                        )
-
-                    // 서버 업데이트
-                    when (
-                        val result =
-                            scheduleRepository.markScheduleAsCompleted(scheduleId, !it.completed)
-                    ) {
-                        is ScheduleRepository.ScheduleResult.Success -> {
-                            Log.d("MainViewModel", "완료 상태 변경 성공")
-                        }
-
-                        is ScheduleRepository.ScheduleResult.Error -> {
-                            Log.e("MainViewModel", "완료 상태 변경 실패: ${result.error.message}")
-                            // 실패 시 원래 상태로 복구
-                            loadSchedules(Calendar.getInstance())
-
-                            _uiState.value =
-                                _uiState.value.copy(
-                                    error = result.error,
-                                    canRetry = false,
-                                )
-                        }
+                    }.collect { reminders ->
+                        val today = Calendar.getInstance()
+                        val todayReminders = reminders.filter { it.startTime.toDate().isSameDay(today) }
+                        dispatch(MainReducerEvent.SharedRemindersLoaded(todayReminders))
+                        val ownerIds = todayReminders.map { it.userId }.filter { it.isNotBlank() }.distinct()
+                        dispatch(MainReducerEvent.SharedReminderOwnersLoaded(userRepository.getUserNames(ownerIds)))
                     }
+            }
+        }
+
+        private fun toggleComplete(scheduleId: String) {
+            val schedule = currentState.todaySchedules.find { it.id == scheduleId } ?: return
+            dispatch(MainReducerEvent.CompletionToggled(scheduleId, System.currentTimeMillis()))
+            viewModelScope.launch {
+                val result = scheduleRepository.markScheduleAsCompleted(scheduleId, !schedule.completed)
+                if (result is ScheduleRepository.ScheduleResult.Error) {
+                    Log.e(TAG, "완료 상태 변경 실패: ${result.error.message}")
+                    dispatch(MainReducerEvent.LoadFailed(result.error, canRetry = false))
                 }
             }
         }
 
-        fun showScheduleDetail(scheduleId: String) {
-            val schedule = _uiState.value.todaySchedules.find { it.id == scheduleId }
-            _uiState.value = _uiState.value.copy(selectedScheduleForDetail = schedule)
-        }
-
-        fun hideScheduleDetail() {
-            _uiState.value = _uiState.value.copy(selectedScheduleForDetail = null)
-        }
-
-        fun clearError() {
-            _uiState.value = _uiState.value.copy(error = null, canRetry = false)
-        }
-
-        fun retryLastAction() {
-            clearError()
-            loadSchedules(Calendar.getInstance())
-        }
-
-        fun showDeleteConfirmDialog(scheduleId: String) {
-            val schedule = _uiState.value.todaySchedules.find { it.id == scheduleId }
-            _uiState.value =
-                _uiState.value.copy(
-                    showDeleteConfirmDialog = true,
-                    scheduleToDelete = schedule,
-                )
-        }
-
-        fun hideDeleteConfirmDialog() {
-            _uiState.value =
-                _uiState.value.copy(
-                    showDeleteConfirmDialog = false,
-                    scheduleToDelete = null,
-                )
-        }
-
-        fun deleteSchedule(scheduleId: String) {
+        private fun deleteSchedule() {
+            val schedule = currentState.scheduleToDelete ?: return
+            dispatch(MainReducerEvent.Deleting)
             viewModelScope.launch {
-                _uiState.value =
-                    _uiState.value.copy(
-                        isLoading = true,
-                        error = null,
-                        showDeleteConfirmDialog = false,
-                        scheduleToDelete = null,
-                    )
-
-                when (val result = scheduleRepository.deleteSchedule(scheduleId)) {
+                when (val result = scheduleRepository.deleteSchedule(schedule.id)) {
                     is ScheduleRepository.ScheduleResult.Success -> {
-                        Log.d("MainViewModel", "일정 삭제 성공")
-                        // 목록에서 제거
-                        val updatedSchedules =
-                            _uiState.value.todaySchedules.filter { it.id != scheduleId }
-                        _uiState.value =
-                            _uiState.value.copy(
-                                todaySchedules = updatedSchedules,
-                                totalCount = updatedSchedules.size,
-                                completedCount = updatedSchedules.count { it.completed },
-                                isLoading = false,
-                            )
+                        dispatch(MainReducerEvent.Deleted(schedule.id, System.currentTimeMillis()))
                     }
 
                     is ScheduleRepository.ScheduleResult.Error -> {
-                        Log.e("MainViewModel", "일정 삭제 실패: ${result.error.message}")
-                        _uiState.value =
-                            _uiState.value.copy(
-                                isLoading = false,
-                                error = result.error,
-                                canRetry = true,
+                        Log.e(TAG, "일정 삭제 실패: ${result.error.message}")
+                        dispatch(MainReducerEvent.LoadFailed(result.error, canRetry = true))
+                    }
+                }
+            }
+        }
+
+        private fun toggleSharedReminderComplete(scheduleId: String) {
+            val reminder = currentState.sharedReminders.find { it.id == scheduleId } ?: return
+            dispatch(MainReducerEvent.SharedReminderToggled(scheduleId))
+            viewModelScope.launch {
+                when (val result = scheduleRepository.markScheduleAsCompleted(scheduleId, !reminder.completed)) {
+                    is ScheduleRepository.ScheduleResult.Success -> {
+                        if (reminder.sharedCode.isNotBlank()) {
+                            val nowCompleted = !reminder.completed
+                            scheduleRepository.sendNotificationToShareCodeMembers(
+                                shareCode = reminder.sharedCode,
+                                title = if (nowCompleted) "일정이 완료됨" else "일정이 미완료로 변경됨",
+                                message = "${reminder.title} 일정이 ${if (nowCompleted) "완료" else "미완료"} 처리되었습니다.",
                             )
+                        }
+                    }
+
+                    is ScheduleRepository.ScheduleResult.Error -> {
+                        dispatch(MainReducerEvent.LoadFailed(result.error, canRetry = false))
                     }
                 }
             }
         }
 
-        fun observeSharedReminders(shareCode: String?) {
-            if (shareCode.isNullOrBlank()) return
-            sharedRemindersJob?.cancel()
-            sharedRemindersJob =
-                viewModelScope.launch {
-                    scheduleRepository.observeSchedulesBySharedCode(shareCode).collectLatest { reminders ->
-                        // Filter reminders to only include those with startTime on today's date
-                        val today = java.util.Calendar.getInstance()
-                        val filteredReminders =
-                            reminders.filter { schedule ->
-                                val cal =
-                                    java.util.Calendar
-                                        .getInstance()
-                                        .apply { time = schedule.startTime.toDate() }
-                                cal.get(java.util.Calendar.YEAR) == today.get(java.util.Calendar.YEAR) &&
-                                    cal.get(java.util.Calendar.DAY_OF_YEAR) == today.get(java.util.Calendar.DAY_OF_YEAR)
-                            }
-                        _uiState.value = _uiState.value.copy(sharedReminders = filteredReminders)
-                        // Optionally update owner names if needed
-                        val userIds = filteredReminders.map { it.userId }.filter { it.isNotBlank() }.distinct()
-                        val ownerMap = userRepository.getUserNames(userIds)
-                        _uiState.value = _uiState.value.copy(sharedReminderOwners = ownerMap)
-                    }
-                }
+        private companion object {
+            const val TAG = "MainViewModel"
         }
-
-        fun toggleSharedReminderComplete(
-            scheduleId: String,
-            context: Context,
-        ) {
-            viewModelScope.launch {
-                val schedule = _uiState.value.sharedReminders.find { it.id == scheduleId }
-                schedule?.let {
-                    // Optimistic update
-                    val updatedReminders =
-                        _uiState.value.sharedReminders.map { s ->
-                            if (s.id == scheduleId) s.copy(completed = !s.completed) else s
-                        }
-                    _uiState.value = _uiState.value.copy(sharedReminders = updatedReminders)
-
-                    // Update in Firestore
-                    when (
-                        val result =
-                            scheduleRepository.markScheduleAsCompleted(scheduleId, !it.completed)
-                    ) {
-                        is ScheduleRepository.ScheduleResult.Success -> {
-                            // Send FCM notification to shareCode members
-                            if (it.sharedCode.isNotBlank()) {
-                                val title = if (!it.completed) "일정이 완료됨" else "일정이 미완료로 변경됨"
-                                val message =
-                                    "${it.title} 일정이 ${if (!it.completed) "완료" else "미완료"} 처리되었습니다."
-                                scheduleRepository.sendNotificationToShareCodeMembers(
-                                    context,
-                                    it.sharedCode,
-                                    title,
-                                    message,
-                                )
-                            }
-                        }
-
-                        is ScheduleRepository.ScheduleResult.Error -> {
-                            // On error, reload shared reminders to revert
-                            val shareCode = it.sharedCode
-                            if (shareCode.isNotBlank()) {
-                                observeSharedReminders(shareCode)
-                            }
-                            _uiState.value =
-                                _uiState.value.copy(
-                                    error = result.error,
-                                    canRetry = false,
-                                )
-                        }
-                    }
-                }
-            }
-        }
-
-        suspend fun notifyShareCodeMembersForSchedule(
-            context: Context,
-            schedule: Schedule,
-            type: String,
-        ) {
-            if (schedule.sharedCode.isBlank()) return
-            val (title, message) =
-                when (type) {
-                    "create" -> "새 일정이 추가되었습니다" to "${schedule.title} 일정이 추가되었습니다."
-                    "edit" -> "일정이 수정되었습니다" to "${schedule.title} 일정이 수정되었습니다."
-                    "delete" -> "일정이 삭제되었습니다" to "${schedule.title} 일정이 삭제되었습니다."
-                    else -> return
-                }
-            scheduleRepository.sendNotificationToShareCodeMembers(context, schedule.sharedCode, title, message)
-        }
-
-        fun addSharedSchedule(
-            schedule: Schedule,
-            context: Context,
-        ) = viewModelScope.launch {
-            val result = scheduleRepository.addSchedule(schedule)
-            if (result is ScheduleRepository.ScheduleResult.Success) {
-                notifyShareCodeMembersForSchedule(context, schedule, "create")
-            }
-        }
-
-        fun updateSharedSchedule(
-            schedule: Schedule,
-            context: Context,
-        ) = viewModelScope.launch {
-            val result = scheduleRepository.updateSchedule(schedule)
-            if (result is ScheduleRepository.ScheduleResult.Success) {
-                notifyShareCodeMembersForSchedule(context, schedule, "edit")
-            }
-        }
-
-        fun deleteSharedSchedule(
-            schedule: Schedule,
-            context: Context,
-        ) = viewModelScope.launch {
-            val result = scheduleRepository.deleteSchedule(schedule.id)
-            if (result is ScheduleRepository.ScheduleResult.Success) {
-                notifyShareCodeMembersForSchedule(context, schedule, "delete")
-            }
-        }
-
-        fun sendTestFcm(context: Context) {
-            viewModelScope.launch {
-                val fcmToken = userRepository.getCurrentUserFcmToken()
-                if (fcmToken == null) {
-                    Log.e("TestFCM", "FCM 토큰이 없습니다.")
-                    return@launch
-                }
-                com.example.slowclock.notification.GuardianNotifier.sendReminderToUser(
-                    context,
-                    fcmToken,
-                    "FCM 테스트",
-                    "이것은 테스트 메시지입니다.",
-                )
-            }
-        }
-
-        // --- ShareCode Watcher Logic ---
-        fun addShareCodeWatcher(
-            context: Context,
-            shareCode: String,
-        ) {
-            viewModelScope.launch {
-                val registered = userRepository.registerShareCodeWatcher(shareCode)
-                Log.d("ShareCodeWatcher", "watcher registered=$registered shareCode=$shareCode")
-                android.widget.Toast
-                    .makeText(
-                        context,
-                        if (registered) "Watcher added!" else "Failed to add watcher",
-                        android.widget.Toast.LENGTH_SHORT,
-                    ).show()
-            }
-        }
-
-        fun removeShareCodeWatcher(shareCode: String) {
-            viewModelScope.launch { userRepository.unregisterShareCodeWatcher(shareCode) }
-        }
-        // --- End ShareCode Watcher Logic ---
     }
+
+private fun Date.isSameDay(other: Calendar): Boolean {
+    val calendar = Calendar.getInstance().apply { time = this@isSameDay }
+    return calendar.get(Calendar.YEAR) == other.get(Calendar.YEAR) &&
+        calendar.get(Calendar.DAY_OF_YEAR) == other.get(Calendar.DAY_OF_YEAR)
+}

--- a/feature/main/src/main/java/com/example/slowclock/ui/settings/SettingsScreenShareCode.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/settings/SettingsScreenShareCode.kt
@@ -1,53 +1,71 @@
 package com.example.slowclock.ui.settings
 
-import android.content.Context
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.slowclock.ui.main.MainViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.slowclock.ui.mvi.ObserveSignal
 
+/** 공유 코드 입력 화면(stateful). 저장이 끝나면 [onReturn] 으로 돌아간다. */
 @Composable
 fun SettingsScreenShareCode(
     onReturn: () -> Unit,
-    viewModel: MainViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
+    viewModel: ShareCodeViewModel = hiltViewModel(),
 ) {
-    val context = LocalContext.current
-    val prefs = remember { context.getSharedPreferences("settings", Context.MODE_PRIVATE) }
-    var shareCode by remember { mutableStateOf(prefs.getString("share_code", "") ?: "") }
-    var inputValue by remember { mutableStateOf(TextFieldValue(shareCode)) }
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
 
+    ObserveSignal(
+        signal = state.isSaved.takeIf { it },
+        consumed = ShareCodeIntent.ConsumeSaved,
+        onIntent = viewModel::onIntent,
+    ) { onReturn() }
+
+    ShareCodeContent(state = state, onIntent = viewModel::onIntent, modifier = modifier)
+}
+
+/** 공유 코드 입력 화면(stateless). */
+@Composable
+internal fun ShareCodeContent(
+    state: ShareCodeUiState,
+    onIntent: (ShareCodeIntent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier =
-            Modifier
+            modifier
                 .fillMaxSize()
                 .padding(24.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text("Enter Share Code to View Shared Reminders", style = MaterialTheme.typography.titleLarge)
+        Text("공유 일정을 볼 공유 코드를 입력하세요", style = MaterialTheme.typography.titleLarge)
         Spacer(modifier = Modifier.height(24.dp))
         OutlinedTextField(
-            value = inputValue,
-            onValueChange = { inputValue = it },
-            label = { Text("Share Code") },
+            value = state.input,
+            onValueChange = { onIntent(ShareCodeIntent.UpdateInput(it)) },
+            label = { Text("공유 코드") },
             singleLine = true,
         )
         Spacer(modifier = Modifier.height(24.dp))
-        Button(onClick = {
-            prefs.edit().putString("share_code", inputValue.text).apply()
-            shareCode = inputValue.text
-            // Register watcher after saving share code
-            viewModel.addShareCodeWatcher(context, inputValue.text)
-            onReturn()
-        }) {
-            Text("Save and Return")
+        Button(
+            onClick = { onIntent(ShareCodeIntent.Save) },
+            enabled = state.canSave,
+        ) {
+            Text(if (state.isSaving) "저장 중..." else "저장하고 돌아가기")
         }
     }
 }

--- a/feature/main/src/main/java/com/example/slowclock/ui/settings/ShareCodeContract.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/settings/ShareCodeContract.kt
@@ -1,0 +1,36 @@
+package com.example.slowclock.ui.settings
+
+import com.example.slowclock.ui.mvi.MviIntent
+import com.example.slowclock.ui.mvi.ReducerEvent
+import com.example.slowclock.ui.mvi.UiState
+
+sealed interface ShareCodeIntent : MviIntent {
+    data class UpdateInput(
+        val value: String,
+    ) : ShareCodeIntent
+
+    data object Save : ShareCodeIntent
+
+    data object ConsumeSaved : ShareCodeIntent
+}
+
+/** [isSaved] 는 일회성 신호다. 화면이 소비하고 [ShareCodeIntent.ConsumeSaved] 로 되돌린다. */
+data class ShareCodeUiState(
+    val input: String = "",
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+) : UiState {
+    val canSave: Boolean get() = input.isNotBlank() && !isSaving
+}
+
+sealed interface ShareCodeReducerEvent : ReducerEvent {
+    data class InputChanged(
+        val value: String,
+    ) : ShareCodeReducerEvent
+
+    data object Saving : ShareCodeReducerEvent
+
+    data object Saved : ShareCodeReducerEvent
+
+    data object SavedConsumed : ShareCodeReducerEvent
+}

--- a/feature/main/src/main/java/com/example/slowclock/ui/settings/ShareCodeViewModel.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/settings/ShareCodeViewModel.kt
@@ -1,0 +1,54 @@
+package com.example.slowclock.ui.settings
+
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import com.example.slowclock.data.remote.repository.SettingsRepository
+import com.example.slowclock.data.remote.repository.UserRepository
+import com.example.slowclock.ui.mvi.MviViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** 공유 코드 입력 화면. 코드를 기기에 저장하고 감시자 토큰을 등록한다. */
+@HiltViewModel
+class ShareCodeViewModel
+    @Inject
+    constructor(
+        private val settingsRepository: SettingsRepository,
+        private val userRepository: UserRepository,
+    ) : MviViewModel<ShareCodeIntent, ShareCodeUiState, ShareCodeReducerEvent>(ShareCodeUiState()) {
+        init {
+            dispatch(ShareCodeReducerEvent.InputChanged(settingsRepository.getShareCode().orEmpty()))
+        }
+
+        override fun onIntent(intent: ShareCodeIntent) {
+            when (intent) {
+                is ShareCodeIntent.UpdateInput -> dispatch(ShareCodeReducerEvent.InputChanged(intent.value))
+                ShareCodeIntent.Save -> save()
+                ShareCodeIntent.ConsumeSaved -> dispatch(ShareCodeReducerEvent.SavedConsumed)
+            }
+        }
+
+        override fun reduce(
+            state: ShareCodeUiState,
+            event: ShareCodeReducerEvent,
+        ): ShareCodeUiState =
+            when (event) {
+                is ShareCodeReducerEvent.InputChanged -> state.copy(input = event.value)
+                ShareCodeReducerEvent.Saving -> state.copy(isSaving = true)
+                ShareCodeReducerEvent.Saved -> state.copy(isSaving = false, isSaved = true)
+                ShareCodeReducerEvent.SavedConsumed -> state.copy(isSaved = false)
+            }
+
+        private fun save() {
+            if (!currentState.canSave) return
+            val shareCode = currentState.input.trim()
+            dispatch(ShareCodeReducerEvent.Saving)
+            viewModelScope.launch {
+                settingsRepository.setShareCode(shareCode)
+                val registered = userRepository.registerShareCodeWatcher(shareCode)
+                Log.d("ShareCodeWatcher", "watcher registered=$registered shareCode=$shareCode")
+                dispatch(ShareCodeReducerEvent.Saved)
+            }
+        }
+    }

--- a/feature/main/src/main/java/com/example/slowclock/ui/timeline/TimelineContract.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/timeline/TimelineContract.kt
@@ -1,0 +1,63 @@
+package com.example.slowclock.ui.timeline
+
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.ui.mvi.MviIntent
+import com.example.slowclock.ui.mvi.ReducerEvent
+import com.example.slowclock.ui.mvi.UiState
+import com.example.slowclock.util.AppError
+import java.util.Calendar
+
+sealed interface TimelineIntent : MviIntent {
+    data class SelectDate(
+        val year: Int,
+        val month: Int,
+        val dayOfMonth: Int,
+    ) : TimelineIntent
+
+    data object NextDay : TimelineIntent
+
+    data object PreviousDay : TimelineIntent
+
+    data object Retry : TimelineIntent
+
+    data object ConsumeError : TimelineIntent
+}
+
+/**
+ * [selectedDate] 는 자정으로 맞춘 날짜다. Calendar 는 가변 객체라 상태에 넣은 뒤에는 바꾸지 않고
+ * 새 인스턴스로 교체한다.
+ */
+data class TimelineUiState(
+    val selectedDate: Calendar = startOfDay(Calendar.getInstance()),
+    val schedules: List<Schedule> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: AppError? = null,
+) : UiState
+
+sealed interface TimelineReducerEvent : ReducerEvent {
+    data class DateChanged(
+        val date: Calendar,
+    ) : TimelineReducerEvent
+
+    data object Loading : TimelineReducerEvent
+
+    data class Loaded(
+        val schedules: List<Schedule>,
+    ) : TimelineReducerEvent
+
+    data class Failed(
+        val error: AppError,
+    ) : TimelineReducerEvent
+
+    data object ErrorConsumed : TimelineReducerEvent
+}
+
+internal fun startOfDay(source: Calendar): Calendar =
+    (source.clone() as Calendar).apply {
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }
+
+internal fun Calendar.plusDays(days: Int): Calendar = (clone() as Calendar).apply { add(Calendar.DAY_OF_MONTH, days) }

--- a/feature/main/src/main/java/com/example/slowclock/ui/timeline/TimelineScreen.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/timeline/TimelineScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -24,74 +23,63 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.slowclock.ui.main.MainViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.slowclock.ui.common.components.ErrorCard
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
+private const val SWIPE_THRESHOLD_PX = 100f
+
+/** 타임라인 화면(stateful). */
 @Composable
 fun TimelineScreen(
-    viewModel: MainViewModel,
+    modifier: Modifier = Modifier,
+    viewModel: TimelineViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    TimelineContent(state = state, onIntent = viewModel::onIntent, modifier = modifier)
+}
+
+/** 타임라인 화면(stateless). 날짜 선택은 DatePickerDialog, 좌우 스와이프로 하루씩 이동한다. */
+@Composable
+internal fun TimelineContent(
+    state: TimelineUiState,
+    onIntent: (TimelineIntent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    // Calendar 및 날짜 수정 Method
-    // 0000년 00월 00일 Format
     val formatter = remember { SimpleDateFormat("yyyy년 MM월 dd일", Locale.KOREA) }
-
-    // 드래그 중첩 방지
     var hasSwiped by remember { mutableStateOf(false) }
+    val selectedDate = state.selectedDate
 
-    // Timeline 날짜 선택 및 이동
-    var calendar = remember { Calendar.getInstance() }
-    val date = remember { mutableStateOf(formatter.format(calendar.time)) }
-
-    val datePickerDialog =
-        DatePickerDialog(
-            context,
-            { _: DatePicker, year: Int, month: Int, dayOfMonth: Int ->
-                calendar.set(year, month, dayOfMonth)
-                date.value = formatter.format(calendar.time)
-            },
-            calendar.get(Calendar.YEAR),
-            calendar.get(Calendar.MONTH),
-            calendar.get(Calendar.DAY_OF_MONTH),
-        )
-
-    val uiState by viewModel.uiState.collectAsState()
-    val filteredSchedules =
-        uiState.todaySchedules.filter { schedule ->
-            val scheduleDate = formatter.format(schedule.startTime.toDate())
-            scheduleDate == date.value
-        }
-
-    // Timeline Screen 컨텐츠
-    BoxWithConstraints(modifier = Modifier.fillMaxSize().padding(top = 50.dp)) {
+    BoxWithConstraints(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(top = 50.dp),
+    ) {
         Column(
             modifier =
                 Modifier
                     .fillMaxWidth()
                     .pointerInput(Unit) {
                         detectHorizontalDragGestures(
-                            onDragStart = {
-                                hasSwiped = false
-                            },
+                            onDragStart = { hasSwiped = false },
                         ) { _, dragAmount ->
                             if (!hasSwiped) {
-                                if (dragAmount > 100) {
-                                    calendar.add(Calendar.DAY_OF_MONTH, -1)
-                                    date.value = formatter.format(calendar.time)
+                                if (dragAmount > SWIPE_THRESHOLD_PX) {
+                                    onIntent(TimelineIntent.PreviousDay)
                                     hasSwiped = true
-                                } else if (dragAmount < -100) {
-                                    calendar.add(Calendar.DAY_OF_MONTH, 1)
-                                    date.value = formatter.format(calendar.time)
+                                } else if (dragAmount < -SWIPE_THRESHOLD_PX) {
+                                    onIntent(TimelineIntent.NextDay)
                                     hasSwiped = true
                                 }
                             }
                         }
                     },
         ) {
-            // 제목 Text
             Text(
                 text = "일정 타임라인",
                 fontSize = 20.sp,
@@ -100,28 +88,47 @@ fun TimelineScreen(
                 modifier =
                     Modifier
                         .align(Alignment.CenterHorizontally)
-                        .clickable {
-                            datePickerDialog.show()
-                        },
+                        .clickable { showDatePicker(context, selectedDate, onIntent) },
             )
-            // Timeline 날짜 Text
             Text(
-                text = date.value,
+                text = formatter.format(selectedDate.time),
                 fontSize = 15.sp,
                 color = Color.Gray,
                 modifier =
                     Modifier
                         .align(Alignment.CenterHorizontally)
-                        .clickable {
-                            datePickerDialog.show()
-                        },
+                        .clickable { showDatePicker(context, selectedDate, onIntent) },
             )
-            // Default : 오늘 날짜, 이후 캘린더 조작 혹은 버튼 클릭으로 날짜 변경 가능
+
+            state.error?.let { error ->
+                ErrorCard(
+                    error = error,
+                    canRetry = true,
+                    onRetry = { onIntent(TimelineIntent.Retry) },
+                    onDismiss = { onIntent(TimelineIntent.ConsumeError) },
+                )
+            }
 
             Timeline(
-                items = filteredSchedules, // Items : DB에서 사용자의 해당 날짜에 존재하는 일정들을 가져와서 사용
+                items = state.schedules,
                 height = this@BoxWithConstraints.maxHeight,
             )
         }
     }
+}
+
+private fun showDatePicker(
+    context: android.content.Context,
+    selectedDate: Calendar,
+    onIntent: (TimelineIntent) -> Unit,
+) {
+    DatePickerDialog(
+        context,
+        { _: DatePicker, year: Int, month: Int, dayOfMonth: Int ->
+            onIntent(TimelineIntent.SelectDate(year, month, dayOfMonth))
+        },
+        selectedDate.get(Calendar.YEAR),
+        selectedDate.get(Calendar.MONTH),
+        selectedDate.get(Calendar.DAY_OF_MONTH),
+    ).show()
 }

--- a/feature/main/src/main/java/com/example/slowclock/ui/timeline/TimelineViewModel.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/timeline/TimelineViewModel.kt
@@ -1,0 +1,91 @@
+package com.example.slowclock.ui.timeline
+
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import com.example.slowclock.data.remote.repository.ScheduleRepository
+import com.example.slowclock.ui.mvi.MviViewModel
+import com.example.slowclock.util.toAppError
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import java.util.Calendar
+import javax.inject.Inject
+
+/** 타임라인 화면. 고른 날짜의 일정을 Firestore 리스너로 받는다. 날짜가 바뀌면 다시 구독한다. */
+@HiltViewModel
+class TimelineViewModel
+    @Inject
+    constructor(
+        private val scheduleRepository: ScheduleRepository,
+    ) : MviViewModel<TimelineIntent, TimelineUiState, TimelineReducerEvent>(TimelineUiState()) {
+        private var scheduleJob: Job? = null
+
+        init {
+            observeSchedules(currentState.selectedDate)
+        }
+
+        override fun onIntent(intent: TimelineIntent) {
+            when (intent) {
+                is TimelineIntent.SelectDate -> {
+                    changeDate(
+                        startOfDay(
+                            Calendar.getInstance().apply { set(intent.year, intent.month, intent.dayOfMonth) },
+                        ),
+                    )
+                }
+
+                TimelineIntent.NextDay -> {
+                    changeDate(currentState.selectedDate.plusDays(1))
+                }
+
+                TimelineIntent.PreviousDay -> {
+                    changeDate(currentState.selectedDate.plusDays(-1))
+                }
+
+                TimelineIntent.Retry -> {
+                    dispatch(TimelineReducerEvent.ErrorConsumed)
+                    observeSchedules(currentState.selectedDate)
+                }
+
+                TimelineIntent.ConsumeError -> {
+                    dispatch(TimelineReducerEvent.ErrorConsumed)
+                }
+            }
+        }
+
+        override fun reduce(
+            state: TimelineUiState,
+            event: TimelineReducerEvent,
+        ): TimelineUiState =
+            when (event) {
+                is TimelineReducerEvent.DateChanged -> state.copy(selectedDate = event.date, schedules = emptyList())
+                TimelineReducerEvent.Loading -> state.copy(isLoading = true, error = null)
+                is TimelineReducerEvent.Loaded -> state.copy(schedules = event.schedules, isLoading = false, error = null)
+                is TimelineReducerEvent.Failed -> state.copy(isLoading = false, error = event.error)
+                TimelineReducerEvent.ErrorConsumed -> state.copy(error = null)
+            }
+
+        private fun changeDate(date: Calendar) {
+            dispatch(TimelineReducerEvent.DateChanged(date))
+            observeSchedules(date)
+        }
+
+        private fun observeSchedules(date: Calendar) {
+            scheduleJob?.cancel()
+            scheduleJob =
+                viewModelScope.launch {
+                    dispatch(TimelineReducerEvent.Loading)
+                    scheduleRepository
+                        .observeSchedulesForDate(date)
+                        .catch { e ->
+                            Log.e(TAG, "일정 구독 실패", e)
+                            dispatch(TimelineReducerEvent.Failed(e.toAppError()))
+                        }.collect { dispatch(TimelineReducerEvent.Loaded(it)) }
+                }
+        }
+
+        private companion object {
+            const val TAG = "TimelineViewModel"
+        }
+    }

--- a/feature/main/src/test/java/com/example/slowclock/ui/done/DoneViewModelTest.kt
+++ b/feature/main/src/test/java/com/example/slowclock/ui/done/DoneViewModelTest.kt
@@ -1,0 +1,75 @@
+package com.example.slowclock.ui.done
+
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.data.remote.repository.ScheduleRepository
+import com.example.slowclock.util.AppError
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DoneViewModelTest {
+    private val scheduleRepository = mockk<ScheduleRepository>()
+    private val todaySchedules = MutableStateFlow<List<Schedule>>(emptyList())
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        every { scheduleRepository.observeSchedulesForDate(any()) } returns todaySchedules
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `오늘 일정을 완료·남은 일정으로 나눈다`() =
+        runTest {
+            todaySchedules.value =
+                listOf(
+                    Schedule(id = "a", title = "a", completed = true),
+                    Schedule(id = "b", title = "b"),
+                )
+
+            val state = DoneViewModel(scheduleRepository).uiState.value
+
+            assertEquals(listOf("a"), state.completed.map { it.id })
+            assertEquals(listOf("b"), state.remaining.map { it.id })
+        }
+
+    @Test
+    fun `토글은 먼저 반영하고 실패하면 오류를 둔다`() =
+        runTest {
+            todaySchedules.value = listOf(Schedule(id = "a", title = "a"))
+            coEvery { scheduleRepository.markScheduleAsCompleted("a", true) } returns
+                ScheduleRepository.ScheduleResult.Error(AppError.NetworkError)
+            val viewModel = DoneViewModel(scheduleRepository)
+
+            viewModel.onIntent(DoneIntent.ToggleComplete("a"))
+
+            assertEquals(
+                listOf("a"),
+                viewModel.uiState.value.completed
+                    .map { it.id },
+            )
+            assertEquals(AppError.NetworkError, viewModel.uiState.value.error)
+            coVerify(exactly = 1) { scheduleRepository.markScheduleAsCompleted("a", true) }
+
+            viewModel.onIntent(DoneIntent.ConsumeError)
+            assertNull(viewModel.uiState.value.error)
+        }
+}

--- a/feature/main/src/test/java/com/example/slowclock/ui/main/MainScheduleSelectorTest.kt
+++ b/feature/main/src/test/java/com/example/slowclock/ui/main/MainScheduleSelectorTest.kt
@@ -1,0 +1,69 @@
+package com.example.slowclock.ui.main
+
+import com.example.slowclock.data.model.Schedule
+import com.google.firebase.Timestamp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Date
+
+class MainScheduleSelectorTest {
+    private val now = 1_800_000_000_000L
+    private val hour = 60 * 60 * 1000L
+
+    private fun schedule(
+        id: String,
+        startOffset: Long,
+        endOffset: Long? = null,
+        completed: Boolean = false,
+    ) = Schedule(
+        id = id,
+        title = id,
+        startTime = Timestamp(Date(now + startOffset)),
+        endTime = endOffset?.let { Timestamp(Date(now + it)) },
+        completed = completed,
+    )
+
+    @Test
+    fun `진행 중인 일정이 있으면 끝나는 시각이 가장 빠른 것을 고른다`() {
+        val schedules =
+            listOf(
+                schedule("late-end", startOffset = -hour, endOffset = 3 * hour),
+                schedule("early-end", startOffset = -2 * hour, endOffset = hour),
+                schedule("future", startOffset = hour),
+            )
+
+        assertEquals("early-end", selectCurrentSchedule(schedules, now)?.id)
+    }
+
+    @Test
+    fun `진행 중인 일정이 없으면 다음에 시작할 일정을 고른다`() {
+        val schedules =
+            listOf(
+                schedule("later", startOffset = 3 * hour),
+                schedule("sooner", startOffset = hour),
+                schedule("past", startOffset = -5 * hour, endOffset = -4 * hour),
+            )
+
+        assertEquals("sooner", selectCurrentSchedule(schedules, now)?.id)
+    }
+
+    @Test
+    fun `종료 시각이 없는 일정은 시작 뒤 한 시간까지 진행 중으로 본다`() {
+        val schedules = listOf(schedule("open-ended", startOffset = -30 * 60 * 1000L))
+
+        assertEquals("open-ended", selectCurrentSchedule(schedules, now)?.id)
+        assertNull(selectCurrentSchedule(schedules, now + 2 * hour))
+    }
+
+    @Test
+    fun `완료한 일정은 후보에서 뺀다`() {
+        val schedules =
+            listOf(
+                schedule("done", startOffset = -hour, endOffset = hour, completed = true),
+                schedule("next", startOffset = 2 * hour),
+            )
+
+        assertEquals("next", selectCurrentSchedule(schedules, now)?.id)
+    }
+}

--- a/feature/main/src/test/java/com/example/slowclock/ui/main/MainViewModelTest.kt
+++ b/feature/main/src/test/java/com/example/slowclock/ui/main/MainViewModelTest.kt
@@ -1,0 +1,199 @@
+package com.example.slowclock.ui.main
+
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.data.remote.repository.AuthRepository
+import com.example.slowclock.data.remote.repository.ScheduleRepository
+import com.example.slowclock.data.remote.repository.SettingsRepository
+import com.example.slowclock.data.remote.repository.UserRepository
+import com.example.slowclock.util.AppError
+import com.google.firebase.Timestamp
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainViewModelTest {
+    private val scheduleRepository = mockk<ScheduleRepository>()
+    private val userRepository = mockk<UserRepository>()
+    private val authRepository = mockk<AuthRepository>()
+    private val settingsRepository = mockk<SettingsRepository>()
+
+    private val todaySchedules = MutableStateFlow<List<Schedule>>(emptyList())
+    private val shareCode = MutableStateFlow<String?>(null)
+
+    private val soon = Schedule(id = "s1", title = "약 먹기", startTime = Timestamp(Date(System.currentTimeMillis() + 60_000)))
+    private val done =
+        Schedule(id = "s2", title = "산책", startTime = Timestamp(Date(System.currentTimeMillis() - 3_600_000)), completed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        every { authRepository.currentUid } returns "uid-1"
+        every { scheduleRepository.observeSchedulesForDate(any()) } returns todaySchedules
+        every { settingsRepository.observeShareCode() } returns shareCode
+        every { scheduleRepository.observeSchedulesBySharedCode(any()) } returns flowOf(emptyList())
+        coEvery { userRepository.getUserNames(any()) } returns emptyMap()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = MainViewModel(scheduleRepository, userRepository, authRepository, settingsRepository)
+
+    @Test
+    fun `리스너가 낸 오늘 일정으로 상태를 채우고 지금 할 일을 고른다`() =
+        runTest {
+            todaySchedules.value = listOf(done, soon)
+
+            val state = createViewModel().uiState.value
+
+            assertEquals("uid-1", state.currentUserId)
+            assertFalse(state.isLoading)
+            assertEquals(2, state.totalCount)
+            assertEquals(1, state.completedCount)
+            assertEquals("s1", state.currentSchedule?.id)
+        }
+
+    @Test
+    fun `완료 토글은 먼저 반영하고 저장소를 부른다`() =
+        runTest {
+            todaySchedules.value = listOf(soon)
+            coEvery { scheduleRepository.markScheduleAsCompleted("s1", true) } returns ScheduleRepository.ScheduleResult.Success(Unit)
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(MainIntent.ToggleComplete("s1"))
+
+            assertTrue(
+                viewModel.uiState.value.todaySchedules
+                    .single()
+                    .completed,
+            )
+            assertEquals(1, viewModel.uiState.value.completedCount)
+            coVerify(exactly = 1) { scheduleRepository.markScheduleAsCompleted("s1", true) }
+        }
+
+    @Test
+    fun `저장소 실패는 재시도 없는 오류로 남고 ConsumeError 로 지운다`() =
+        runTest {
+            todaySchedules.value = listOf(soon)
+            coEvery { scheduleRepository.markScheduleAsCompleted("s1", true) } returns
+                ScheduleRepository.ScheduleResult.Error(AppError.NetworkError)
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(MainIntent.ToggleComplete("s1"))
+            assertEquals(AppError.NetworkError, viewModel.uiState.value.error)
+            assertFalse(viewModel.uiState.value.canRetry)
+
+            viewModel.onIntent(MainIntent.ConsumeError)
+            assertNull(viewModel.uiState.value.error)
+        }
+
+    @Test
+    fun `삭제는 확인 다이얼로그를 거쳐 목록에서 뺀다`() =
+        runTest {
+            todaySchedules.value = listOf(soon, done)
+            coEvery { scheduleRepository.deleteSchedule("s1") } returns ScheduleRepository.ScheduleResult.Success(Unit)
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(MainIntent.RequestDelete("s1"))
+            assertEquals(
+                "s1",
+                viewModel.uiState.value.scheduleToDelete
+                    ?.id,
+            )
+
+            viewModel.onIntent(MainIntent.ConfirmDelete)
+
+            val state = viewModel.uiState.value
+            assertNull(state.scheduleToDelete)
+            assertFalse(state.isLoading)
+            assertEquals(listOf("s2"), state.todaySchedules.map { it.id })
+            coVerify(exactly = 1) { scheduleRepository.deleteSchedule("s1") }
+        }
+
+    @Test
+    fun `삭제를 취소하면 저장소를 부르지 않는다`() =
+        runTest {
+            todaySchedules.value = listOf(soon)
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(MainIntent.RequestDelete("s1"))
+            viewModel.onIntent(MainIntent.DismissDelete)
+
+            assertNull(viewModel.uiState.value.scheduleToDelete)
+            coVerify(exactly = 0) { scheduleRepository.deleteSchedule(any()) }
+        }
+
+    @Test
+    fun `일정 구독이 실패하면 재시도 가능한 오류를 두고 Retry 가 다시 구독한다`() =
+        runTest {
+            every { scheduleRepository.observeSchedulesForDate(any()) } returns flow { throw IllegalStateException("network down") }
+            val viewModel = createViewModel()
+            assertEquals(AppError.NetworkError, viewModel.uiState.value.error)
+            assertTrue(viewModel.uiState.value.canRetry)
+
+            every { scheduleRepository.observeSchedulesForDate(any()) } returns flowOf(listOf(soon))
+            viewModel.onIntent(MainIntent.Retry)
+
+            assertNull(viewModel.uiState.value.error)
+            assertEquals(
+                listOf("s1"),
+                viewModel.uiState.value.todaySchedules
+                    .map { it.id },
+            )
+        }
+
+    @Test
+    fun `공유 코드가 있으면 오늘 공유 일정과 소유자 이름을 채운다`() =
+        runTest {
+            val shared = soon.copy(id = "shared-1", userId = "owner-1", sharedCode = "ABC123")
+            every { scheduleRepository.observeSchedulesBySharedCode("ABC123") } returns flowOf(listOf(shared))
+            coEvery { userRepository.getUserNames(listOf("owner-1")) } returns mapOf("owner-1" to "어머니")
+            shareCode.value = "ABC123"
+
+            val state = createViewModel().uiState.value
+
+            assertEquals(listOf("shared-1"), state.sharedReminders.map { it.id })
+            assertEquals("어머니", state.sharedReminderOwners["owner-1"])
+        }
+
+    @Test
+    fun `공유 일정 완료 토글은 공유 코드 구성원에게 알린다`() =
+        runTest {
+            val shared = soon.copy(id = "shared-1", userId = "owner-1", sharedCode = "ABC123")
+            every { scheduleRepository.observeSchedulesBySharedCode("ABC123") } returns flowOf(listOf(shared))
+            coEvery { scheduleRepository.markScheduleAsCompleted("shared-1", true) } returns ScheduleRepository.ScheduleResult.Success(Unit)
+            coEvery { scheduleRepository.sendNotificationToShareCodeMembers(any(), any(), any()) } returns Unit
+            shareCode.value = "ABC123"
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(MainIntent.ToggleSharedReminderComplete("shared-1"))
+
+            assertTrue(
+                viewModel.uiState.value.sharedReminders
+                    .single()
+                    .completed,
+            )
+            coVerify(exactly = 1) { scheduleRepository.sendNotificationToShareCodeMembers("ABC123", "일정이 완료됨", any()) }
+        }
+}

--- a/feature/main/src/test/java/com/example/slowclock/ui/settings/ShareCodeViewModelTest.kt
+++ b/feature/main/src/test/java/com/example/slowclock/ui/settings/ShareCodeViewModelTest.kt
@@ -1,0 +1,76 @@
+package com.example.slowclock.ui.settings
+
+import com.example.slowclock.data.remote.repository.SettingsRepository
+import com.example.slowclock.data.remote.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ShareCodeViewModelTest {
+    private val settingsRepository = mockk<SettingsRepository>()
+    private val userRepository = mockk<UserRepository>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        every { settingsRepository.getShareCode() } returns "OLD001"
+        justRun { settingsRepository.setShareCode(any()) }
+        coEvery { userRepository.registerShareCodeWatcher(any()) } returns true
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `저장된 공유 코드로 입력을 채운다`() =
+        runTest {
+            assertEquals("OLD001", ShareCodeViewModel(settingsRepository, userRepository).uiState.value.input)
+        }
+
+    @Test
+    fun `저장하면 설정에 쓰고 감시자를 등록한 뒤 저장 신호를 낸다`() =
+        runTest {
+            val viewModel = ShareCodeViewModel(settingsRepository, userRepository)
+
+            viewModel.onIntent(ShareCodeIntent.UpdateInput(" NEW002 "))
+            viewModel.onIntent(ShareCodeIntent.Save)
+
+            verify(exactly = 1) { settingsRepository.setShareCode("NEW002") }
+            coVerify(exactly = 1) { userRepository.registerShareCodeWatcher("NEW002") }
+            assertTrue(viewModel.uiState.value.isSaved)
+            assertFalse(viewModel.uiState.value.isSaving)
+
+            viewModel.onIntent(ShareCodeIntent.ConsumeSaved)
+            assertFalse(viewModel.uiState.value.isSaved)
+        }
+
+    @Test
+    fun `빈 입력은 저장하지 않는다`() =
+        runTest {
+            val viewModel = ShareCodeViewModel(settingsRepository, userRepository)
+
+            viewModel.onIntent(ShareCodeIntent.UpdateInput("   "))
+            viewModel.onIntent(ShareCodeIntent.Save)
+
+            verify(exactly = 0) { settingsRepository.setShareCode(any()) }
+            assertFalse(viewModel.uiState.value.isSaved)
+        }
+}

--- a/feature/main/src/test/java/com/example/slowclock/ui/timeline/TimelineViewModelTest.kt
+++ b/feature/main/src/test/java/com/example/slowclock/ui/timeline/TimelineViewModelTest.kt
@@ -1,0 +1,82 @@
+package com.example.slowclock.ui.timeline
+
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.data.remote.repository.ScheduleRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Calendar
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimelineViewModelTest {
+    private val scheduleRepository = mockk<ScheduleRepository>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        every { scheduleRepository.observeSchedulesForDate(any()) } returns flowOf(listOf(Schedule(id = "a", title = "a")))
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `처음에는 오늘 자정을 기준으로 구독한다`() =
+        runTest {
+            val requested = slot<Calendar>()
+            every { scheduleRepository.observeSchedulesForDate(capture(requested)) } returns flowOf(emptyList())
+
+            val state = TimelineViewModel(scheduleRepository).uiState.value
+
+            val today = Calendar.getInstance()
+            assertEquals(today.get(Calendar.DAY_OF_YEAR), requested.captured.get(Calendar.DAY_OF_YEAR))
+            assertEquals(0, requested.captured.get(Calendar.HOUR_OF_DAY))
+            assertEquals(0, state.selectedDate.get(Calendar.HOUR_OF_DAY))
+        }
+
+    @Test
+    fun `날짜를 고르면 그 날짜로 다시 구독한다`() =
+        runTest {
+            val viewModel = TimelineViewModel(scheduleRepository)
+
+            viewModel.onIntent(TimelineIntent.SelectDate(2026, Calendar.SEPTEMBER, 20))
+
+            val selected = viewModel.uiState.value.selectedDate
+            assertEquals(2026, selected.get(Calendar.YEAR))
+            assertEquals(Calendar.SEPTEMBER, selected.get(Calendar.MONTH))
+            assertEquals(20, selected.get(Calendar.DAY_OF_MONTH))
+            assertEquals(
+                listOf("a"),
+                viewModel.uiState.value.schedules
+                    .map { it.id },
+            )
+            verify(exactly = 2) { scheduleRepository.observeSchedulesForDate(any()) }
+        }
+
+    @Test
+    fun `다음 날과 이전 날은 하루씩 옮긴다`() =
+        runTest {
+            val viewModel = TimelineViewModel(scheduleRepository)
+            val start = viewModel.uiState.value.selectedDate
+
+            viewModel.onIntent(TimelineIntent.NextDay)
+            assertEquals(start.timeInMillis + 24 * 60 * 60 * 1000L, viewModel.uiState.value.selectedDate.timeInMillis)
+
+            viewModel.onIntent(TimelineIntent.PreviousDay)
+            assertEquals(start.timeInMillis, viewModel.uiState.value.selectedDate.timeInMillis)
+        }
+}


### PR DESCRIPTION
## 📌 Issues

Closes #26
Refs #53

## 📎 Work Description

메인·완료·타임라인·공유 코드 화면이 한 ViewModel(500줄)을 나눠 쓰던 구조를 화면별 MVI ViewModel 로 바꿨다. 모두 `MviViewModel` 상속, `XxxContract.kt`(Intent·UiState·ReducerEvent), `Screen`/`Content` 2단이다.

- `MainViewModel`: 오늘 일정은 `ScheduleRepository.observeSchedulesForDate` 리스너로 받는다. 완료 토글·삭제는 `CompletionToggled`·`Deleted` 로 먼저 반영하고 저장소가 실패하면 오류를 두며 리스너가 서버 상태로 되돌린다. 공유 일정은 `SettingsRepository.observeShareCode()` 가 바뀔 때마다 `flatMapLatest` 로 다시 구독한다. 「지금 할 일」 선택은 순수 함수 `selectCurrentSchedule(schedules, nowMillis)` 로 빼서 리듀서가 시계를 읽지 않게 했다.
- `DoneViewModel`·`TimelineViewModel`: 각자 오늘 또는 고른 날짜의 일정을 구독한다. 타임라인은 예전에 메인의 오늘 일정을 날짜 문자열로 거르고 있어 다른 날짜가 늘 비어 있었는데, 이제 고른 날짜를 직접 구독한다.
- `ShareCodeViewModel`: 공유 코드 저장과 감시자 등록. 저장 완료는 `isSaved` 신호 + `ConsumeSaved` 로 화면이 소비한다.
- 새로고침 플래그(`savedStateHandle["schedule_added"]`)와 `AppNavigation` 의 공용 `mainViewModel` 인자를 없앴다. 리스너가 변경을 밀어 주므로 필요 없다.
- `SettingsRepository`(SharedPreferences) 를 두어 화면이 preferences 를 직접 읽지 않는다.
- `Notifier` 에서 `Context` 인자를 뺐다. `GuardianNotifier` 는 `@ApplicationContext` 를 받는 `@Singleton` 클래스가 되고 Volley 큐를 하나만 유지한다. `NotifierModule` 은 `@Binds`. Repository 의 알림 메서드 시그니처도 따라 바뀌었다.
- 사용처가 없던 `addSharedSchedule`·`updateSharedSchedule`·`deleteSharedSchedule`·`notifyShareCodeMembersForSchedule`·`sendTestFcm` 을 지웠다.

단위 테스트 20건: `MainViewModelTest` 8(로드·토글·실패·삭제·취소·재구독·공유 일정·공유 알림), `MainScheduleSelectorTest` 4, `DoneViewModelTest` 2, `TimelineViewModelTest` 3, `ShareCodeViewModelTest` 3. `feature/main` 에 `unitTests.isReturnDefaultValues = true` 를 켰다. ViewModel 의 `Log` 호출이 JVM 테스트에서 예외를 던져 오류 경로 테스트가 조용히 빠져나갔기 때문이다.

로컬 검증: `ktlintCheck`, `:feature:main:testDebugUnitTest`, `:app:assembleDebug`, `:app:assembleRelease`, `:app:lintDebug`, `:app:testDebugUnitTest` 통과.

## 📷 Screenshot

화면 구성은 그대로다. 공유 코드 화면의 문구만 한국어로 바꿨다("Enter Share Code..." → "공유 일정을 볼 공유 코드를 입력하세요").

## 💬 To Reviewers

- 완료·타임라인 화면의 하드코딩 색상은 그대로 두었다. #30 에서 한꺼번에 바꾼다.
- 일정 수정 화면에서 돌아올 때 성공·취소 모두 메인으로 돌아간다. 예전에는 성공 시 플래그만 세우고 이동하지 않는 분기가 있었다.
- 기기에서 확인할 것: 메인에서 완료 토글 뒤 리스너가 같은 상태를 다시 내는지, 공유 코드 저장 뒤 메인의 공유 일정이 갱신되는지.