### PR TITLE
refactor: AddSchedule 를 MVI 로 옮기고 알람 예약을 AlarmScheduler 로 분리

### DIFF
--- a/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
@@ -104,7 +104,14 @@ fun AppNavigation(modifier: Modifier = Modifier) {
             }
 
             composable("recommendation") {
-                RecommendationScreen(navController = navController)
+                RecommendationScreen(
+                    onSelectRecommendation = { title ->
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set("initial_title", title)
+                        navController.popBackStack()
+                    },
+                )
             }
 
             composable("settings_share_code") {

--- a/core/alarm/src/main/java/com/example/slowclock/core/alarm/AlarmScheduler.kt
+++ b/core/alarm/src/main/java/com/example/slowclock/core/alarm/AlarmScheduler.kt
@@ -1,0 +1,26 @@
+package com.example.slowclock.core.alarm
+
+import android.content.Context
+import com.example.slowclock.data.model.Schedule
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 일정 알람 예약·취소. ViewModel 이 Context 를 들지 않도록 앱 Context 를 여기서 주입받는다.
+ * 실제 AlarmManager 조작은 [ScheduleAlarmHelper] 가 한다.
+ */
+@Singleton
+class AlarmScheduler
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) {
+        fun schedule(schedule: Schedule) {
+            ScheduleAlarmHelper.scheduleAlarm(context, schedule)
+        }
+
+        fun cancel(schedule: Schedule) {
+            ScheduleAlarmHelper.cancelAlarm(context, schedule)
+        }
+    }

--- a/feature/addschedule/build.gradle.kts
+++ b/feature/addschedule/build.gradle.kts
@@ -23,6 +23,9 @@ android {
     buildFeatures {
         compose = true
     }
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -39,5 +42,7 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 
-    implementation(libs.firebase.auth)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleContract.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleContract.kt
@@ -1,0 +1,114 @@
+package com.example.slowclock.ui.addschedule
+
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.ui.mvi.MviIntent
+import com.example.slowclock.ui.mvi.ReducerEvent
+import com.example.slowclock.ui.mvi.UiState
+import com.example.slowclock.util.AppError
+import java.util.Calendar
+
+sealed interface AddScheduleIntent : MviIntent {
+    data class UpdateTitle(
+        val value: String,
+    ) : AddScheduleIntent
+
+    data class UpdateDescription(
+        val value: String,
+    ) : AddScheduleIntent
+
+    data class UpdateTime(
+        val time: Calendar,
+    ) : AddScheduleIntent
+
+    data class UpdateEndTime(
+        val time: Calendar?,
+    ) : AddScheduleIntent
+
+    data class UpdateRecurring(
+        val recurring: Boolean,
+    ) : AddScheduleIntent
+
+    data class UpdateRecurringType(
+        val type: String,
+    ) : AddScheduleIntent
+
+    data class LoadForEdit(
+        val scheduleId: String,
+    ) : AddScheduleIntent
+
+    data object Save : AddScheduleIntent
+
+    data object Retry : AddScheduleIntent
+
+    data object ConsumeError : AddScheduleIntent
+
+    data object ConsumeSaved : AddScheduleIntent
+}
+
+/**
+ * 일정 추가·수정 화면의 단일 UI 상태. [isSaved] 는 일회성 신호다.
+ * Calendar 는 가변 객체라 상태에 넣은 뒤 바꾸지 않고 새 인스턴스로 교체한다.
+ */
+data class AddScheduleUiState(
+    val title: String = "",
+    val description: String = "",
+    val selectedTime: Calendar = Calendar.getInstance(),
+    val endTime: Calendar? = null,
+    val recurring: Boolean = false,
+    val recurringType: String = "daily",
+    val isLoading: Boolean = false,
+    val isSaved: Boolean = false,
+    val error: AppError? = null,
+    val canRetry: Boolean = false,
+    val isEditMode: Boolean = false,
+    val editingSchedule: Schedule? = null,
+) : UiState {
+    val canSave: Boolean get() = title.isNotBlank() && !isLoading
+}
+
+sealed interface AddScheduleReducerEvent : ReducerEvent {
+    data class TitleChanged(
+        val value: String,
+    ) : AddScheduleReducerEvent
+
+    data class DescriptionChanged(
+        val value: String,
+    ) : AddScheduleReducerEvent
+
+    data class TimeChanged(
+        val time: Calendar,
+    ) : AddScheduleReducerEvent
+
+    data class EndTimeChanged(
+        val time: Calendar?,
+    ) : AddScheduleReducerEvent
+
+    data class RecurringChanged(
+        val recurring: Boolean,
+    ) : AddScheduleReducerEvent
+
+    data class RecurringTypeChanged(
+        val type: String,
+    ) : AddScheduleReducerEvent
+
+    data object EditLoading : AddScheduleReducerEvent
+
+    data class EditLoaded(
+        val schedule: Schedule,
+        val startTime: Calendar,
+        val endTime: Calendar?,
+    ) : AddScheduleReducerEvent
+
+    data object Saving : AddScheduleReducerEvent
+
+    data object Saved : AddScheduleReducerEvent
+
+    data class Failed(
+        val error: AppError,
+        val canRetry: Boolean,
+    ) : AddScheduleReducerEvent
+
+    data object ErrorConsumed : AddScheduleReducerEvent
+
+    data object SavedConsumed : AddScheduleReducerEvent
+}

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
@@ -1,12 +1,12 @@
 package com.example.slowclock.ui.addschedule
 
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -27,64 +27,76 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.ui.addschedule.components.RecommendationPlaceholder
 import com.example.slowclock.ui.addschedule.components.RecurringSection
 import com.example.slowclock.ui.addschedule.components.TimePickerSection
 import com.example.slowclock.ui.addschedule.components.TitleInputSection
+import com.example.slowclock.ui.mvi.ObserveSignal
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * 일정 추가·수정 화면(stateful). [scheduleId] 가 있으면 수정 모드로 불러오고, [initialTitle] 은
+ * 추천 화면에서 고른 제목이다. 저장이 끝나면 [onNavigateBack] 으로 돌아간다.
+ */
 @Composable
 fun AddScheduleScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToRecommendation: () -> Unit,
+    modifier: Modifier = Modifier,
     scheduleId: String? = null,
     initialTitle: String? = null,
-    onNavigateBack: (Boolean) -> Unit,
     viewModel: AddScheduleViewModel = hiltViewModel(),
-    onNavigateToRecommendation: () -> Unit,
 ) {
-    val scrollState = remember { ScrollState(0) }
-    val uiState by viewModel.uiState.collectAsState()
-    val isEditMode = !scheduleId.isNullOrBlank()
-    val context = LocalContext.current
-
-    LaunchedEffect(Unit) {
-        scrollState.scrollTo(0)
-    }
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(scheduleId) {
-        if (!scheduleId.isNullOrBlank()) {
-            viewModel.loadScheduleForEdit(scheduleId)
-        }
+        if (!scheduleId.isNullOrBlank()) viewModel.onIntent(AddScheduleIntent.LoadForEdit(scheduleId))
     }
     LaunchedEffect(initialTitle) {
-        if (!initialTitle.isNullOrBlank()) {
-            viewModel.updateTitle(initialTitle)
-        }
+        if (!initialTitle.isNullOrBlank()) viewModel.onIntent(AddScheduleIntent.UpdateTitle(initialTitle))
     }
-    LaunchedEffect(uiState.isSuccess) {
-        if (uiState.isSuccess) {
-            onNavigateBack(true)
-        }
-    }
+    ObserveSignal(
+        signal = state.isSaved.takeIf { it },
+        consumed = AddScheduleIntent.ConsumeSaved,
+        onIntent = viewModel::onIntent,
+    ) { onNavigateBack() }
 
+    AddScheduleContent(
+        state = state,
+        onIntent = viewModel::onIntent,
+        onNavigateBack = onNavigateBack,
+        onNavigateToRecommendation = onNavigateToRecommendation,
+        modifier = modifier,
+    )
+}
+
+/** 일정 추가·수정 화면(stateless). 프리뷰·스크린샷 테스트 진입점이다. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AddScheduleContent(
+    state: AddScheduleUiState,
+    onIntent: (AddScheduleIntent) -> Unit,
+    onNavigateBack: () -> Unit,
+    onNavigateToRecommendation: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Scaffold(
+        modifier = modifier,
         topBar = {
             CenterAlignedTopAppBar(
                 title = {
                     Text(
-                        text = if (isEditMode) "일정 수정" else "일정 추가",
+                        text = if (state.isEditMode) "일정 수정" else "일정 추가",
                         style = MaterialTheme.typography.headlineSmall,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
                 },
                 navigationIcon = {
-                    IconButton(onClick = { onNavigateBack(false) }) {
+                    IconButton(onClick = onNavigateBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "뒤로가기",
@@ -101,9 +113,9 @@ fun AddScheduleScreen(
         },
         floatingActionButton = {
             FloatingActionButton(
-                onClick = { viewModel.saveSchedule(context) },
+                onClick = { onIntent(AddScheduleIntent.Save) },
                 containerColor =
-                    if (uiState.canSave) {
+                    if (state.canSave) {
                         MaterialTheme.colorScheme.secondary
                     } else {
                         MaterialTheme.colorScheme.surfaceVariant
@@ -114,7 +126,7 @@ fun AddScheduleScreen(
                     Icons.Default.Check,
                     contentDescription = "저장",
                     tint =
-                        if (uiState.canSave) {
+                        if (state.canSave) {
                             MaterialTheme.colorScheme.onSecondary
                         } else {
                             MaterialTheme.colorScheme.onSurfaceVariant
@@ -129,41 +141,36 @@ fun AddScheduleScreen(
                 Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .verticalScroll(scrollState)
+                    .verticalScroll(rememberScrollState())
                     .padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(28.dp),
         ) {
-            // 일정 제목 입력 (분리된 컴포넌트)
             TitleInputSection(
-                title = uiState.title,
-                description = uiState.description,
-                onTitleChange = viewModel::updateTitle,
-                onDescriptionChange = viewModel::updateDescription,
+                title = state.title,
+                description = state.description,
+                onTitleChange = { onIntent(AddScheduleIntent.UpdateTitle(it)) },
+                onDescriptionChange = { onIntent(AddScheduleIntent.UpdateDescription(it)) },
             )
 
-            // 시간 선택
             TimePickerSection(
-                selectedTime = uiState.selectedTime,
-                endTime = uiState.endTime,
-                onTimeSelected = viewModel::updateTime,
-                onEndTimeSelected = viewModel::updateEndTime,
+                selectedTime = state.selectedTime,
+                endTime = state.endTime,
+                onTimeSelected = { onIntent(AddScheduleIntent.UpdateTime(it)) },
+                onEndTimeSelected = { onIntent(AddScheduleIntent.UpdateEndTime(it)) },
             )
 
-            // 반복 일정 설정 (분리된 컴포넌트)
             RecurringSection(
-                recurring = uiState.recurring,
-                recurringType = uiState.recurringType,
-                onRecurringChange = viewModel::updateRecurring,
-                onRecurringTypeChange = viewModel::updateRecurringType,
+                recurring = state.recurring,
+                recurringType = state.recurringType,
+                onRecurringChange = { onIntent(AddScheduleIntent.UpdateRecurring(it)) },
+                onRecurringTypeChange = { onIntent(AddScheduleIntent.UpdateRecurringType(it)) },
             )
 
-            // 추천 기능 영역
             RecommendationPlaceholder(
                 onNavigateToRecommendation = onNavigateToRecommendation,
             )
 
-            // 에러 메시지
-            if (uiState.error != null) {
+            state.error?.let { error ->
                 Card(
                     colors =
                         CardDefaults.cardColors(
@@ -172,24 +179,24 @@ fun AddScheduleScreen(
                 ) {
                     Column(modifier = Modifier.padding(20.dp)) {
                         Text(
-                            text = uiState.error!!.message,
+                            text = error.message,
                             color = MaterialTheme.colorScheme.onErrorContainer,
                             style = MaterialTheme.typography.bodyLarge,
                         )
 
-                        if (uiState.canRetry) {
+                        if (state.canRetry) {
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                             ) {
                                 OutlinedButton(
-                                    onClick = { viewModel.clearError() },
+                                    onClick = { onIntent(AddScheduleIntent.ConsumeError) },
                                     modifier = Modifier.weight(1f),
                                 ) {
                                     Text("닫기")
                                 }
 
                                 Button(
-                                    onClick = { viewModel.retryLastAction(context) },
+                                    onClick = { onIntent(AddScheduleIntent.Retry) },
                                     modifier = Modifier.weight(1f),
                                 ) {
                                     Text("다시 시도")
@@ -200,8 +207,7 @@ fun AddScheduleScreen(
                 }
             }
 
-            // 로딩 상태
-            if (uiState.isLoading) {
+            if (state.isLoading) {
                 Card(
                     colors =
                         CardDefaults.cardColors(
@@ -217,7 +223,7 @@ fun AddScheduleScreen(
                             color = MaterialTheme.colorScheme.primary,
                         )
                         Text(
-                            text = "일정을 저장하는 중...",
+                            text = if (state.isEditMode && state.editingSchedule == null) "일정을 불러오는 중..." else "일정을 저장하는 중...",
                             style = MaterialTheme.typography.bodyLarge,
                             color = MaterialTheme.colorScheme.onPrimaryContainer,
                         )

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleViewModel.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleViewModel.kt
@@ -1,266 +1,242 @@
 package com.example.slowclock.ui.addschedule
 
-import android.content.Context
 import android.util.Log
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.slowclock.core.alarm.ScheduleAlarmHelper
+import com.example.slowclock.core.alarm.AlarmScheduler
 import com.example.slowclock.data.model.Schedule
 import com.example.slowclock.data.remote.repository.ScheduleRepository
-import com.example.slowclock.notification.requestExactAlarmPermissionIfNeeded
+import com.example.slowclock.ui.mvi.MviViewModel
 import com.example.slowclock.util.AppError
 import com.google.firebase.Timestamp
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.util.Calendar
 import javax.inject.Inject
 
-data class AddScheduleUiState(
-    val title: String = "",
-    val description: String = "",
-    val selectedTime: Calendar = Calendar.getInstance(),
-    val endTime: Calendar? = null,
-    val recurring: Boolean = false,
-    val recurringType: String = "daily",
-    val showTimePicker: Boolean = false,
-    val showEndTimePicker: Boolean = false,
-    val isLoading: Boolean = false,
-    val isSuccess: Boolean = false,
-    val error: AppError? = null,
-    val canSave: Boolean = false,
-    val canRetry: Boolean = false,
-    val isEditMode: Boolean = false,
-    val editingScheduleId: String = "",
-    val editingSchedule: Schedule? = null, // <-- add this
-)
+private const val MAX_TITLE_LENGTH = 100
 
+/** 일정 추가·수정 화면. 저장이 끝나면 알람을 예약하고 [AddScheduleUiState.isSaved] 신호를 낸다. */
 @HiltViewModel
 class AddScheduleViewModel
     @Inject
     constructor(
         private val scheduleRepository: ScheduleRepository,
-    ) : ViewModel() {
-        private val _uiState = MutableStateFlow(AddScheduleUiState())
-        val uiState: StateFlow<AddScheduleUiState> = _uiState.asStateFlow()
-
-        fun updateTitle(title: String) {
-            _uiState.value =
-                _uiState.value.copy(
-                    title = title,
-                    canSave = title.trim().isNotBlank(),
-                    error = null,
-                )
-        }
-
-        fun updateDescription(description: String) {
-            _uiState.value = _uiState.value.copy(description = description)
-        }
-
-        fun updateTime(time: Calendar) {
-            val newTime =
-                Calendar.getInstance().apply {
-                    timeInMillis = time.timeInMillis
+        private val alarmScheduler: AlarmScheduler,
+    ) : MviViewModel<AddScheduleIntent, AddScheduleUiState, AddScheduleReducerEvent>(AddScheduleUiState()) {
+        override fun onIntent(intent: AddScheduleIntent) {
+            when (intent) {
+                is AddScheduleIntent.UpdateTitle -> {
+                    dispatch(AddScheduleReducerEvent.TitleChanged(intent.value))
                 }
-            _uiState.value = _uiState.value.copy(selectedTime = newTime)
-        }
 
-        fun updateEndTime(time: Calendar?) {
-            val newTime =
-                time?.let {
-                    Calendar.getInstance().apply { timeInMillis = it.timeInMillis }
+                is AddScheduleIntent.UpdateDescription -> {
+                    dispatch(AddScheduleReducerEvent.DescriptionChanged(intent.value))
                 }
-            _uiState.value = _uiState.value.copy(endTime = newTime)
+
+                is AddScheduleIntent.UpdateTime -> {
+                    dispatch(AddScheduleReducerEvent.TimeChanged(intent.time.copyOf()))
+                }
+
+                is AddScheduleIntent.UpdateEndTime -> {
+                    dispatch(AddScheduleReducerEvent.EndTimeChanged(intent.time?.copyOf()))
+                }
+
+                is AddScheduleIntent.UpdateRecurring -> {
+                    dispatch(AddScheduleReducerEvent.RecurringChanged(intent.recurring))
+                }
+
+                is AddScheduleIntent.UpdateRecurringType -> {
+                    dispatch(AddScheduleReducerEvent.RecurringTypeChanged(intent.type))
+                }
+
+                is AddScheduleIntent.LoadForEdit -> {
+                    loadForEdit(intent.scheduleId)
+                }
+
+                AddScheduleIntent.Save -> {
+                    save()
+                }
+
+                AddScheduleIntent.Retry -> {
+                    dispatch(AddScheduleReducerEvent.ErrorConsumed)
+                    save()
+                }
+
+                AddScheduleIntent.ConsumeError -> {
+                    dispatch(AddScheduleReducerEvent.ErrorConsumed)
+                }
+
+                AddScheduleIntent.ConsumeSaved -> {
+                    dispatch(AddScheduleReducerEvent.SavedConsumed)
+                }
+            }
         }
 
-        fun updateRecurring(recurring: Boolean) {
-            _uiState.value = _uiState.value.copy(recurring = recurring)
-        }
+        override fun reduce(
+            state: AddScheduleUiState,
+            event: AddScheduleReducerEvent,
+        ): AddScheduleUiState =
+            when (event) {
+                is AddScheduleReducerEvent.TitleChanged -> {
+                    state.copy(title = event.value, error = null)
+                }
 
-        fun updateRecurringType(type: String) {
-            _uiState.value = _uiState.value.copy(recurringType = type)
-        }
+                is AddScheduleReducerEvent.DescriptionChanged -> {
+                    state.copy(description = event.value)
+                }
 
-        fun showTimePicker(show: Boolean) {
-            _uiState.value = _uiState.value.copy(showTimePicker = show)
-        }
+                is AddScheduleReducerEvent.TimeChanged -> {
+                    state.copy(selectedTime = event.time)
+                }
 
-        fun showEndTimePicker(show: Boolean) {
-            _uiState.value = _uiState.value.copy(showEndTimePicker = show)
-        }
+                is AddScheduleReducerEvent.EndTimeChanged -> {
+                    state.copy(endTime = event.time)
+                }
 
-        fun loadScheduleForEdit(scheduleId: String) {
-            viewModelScope.launch {
-                _uiState.value =
-                    _uiState.value.copy(
-                        isLoading = true,
-                        error = null,
-                        isEditMode = true,
-                        editingScheduleId = scheduleId,
+                is AddScheduleReducerEvent.RecurringChanged -> {
+                    state.copy(recurring = event.recurring)
+                }
+
+                is AddScheduleReducerEvent.RecurringTypeChanged -> {
+                    state.copy(recurringType = event.type)
+                }
+
+                AddScheduleReducerEvent.EditLoading -> {
+                    state.copy(isLoading = true, error = null, isEditMode = true)
+                }
+
+                is AddScheduleReducerEvent.EditLoaded -> {
+                    state.copy(
+                        title = event.schedule.title,
+                        description = event.schedule.description,
+                        selectedTime = event.startTime,
+                        endTime = event.endTime,
+                        recurring = event.schedule.recurring,
+                        recurringType = event.schedule.recurringType ?: "daily",
+                        isLoading = false,
+                        editingSchedule = event.schedule,
                     )
+                }
 
+                AddScheduleReducerEvent.Saving -> {
+                    state.copy(isLoading = true, error = null, canRetry = false)
+                }
+
+                AddScheduleReducerEvent.Saved -> {
+                    state.copy(isLoading = false, isSaved = true)
+                }
+
+                is AddScheduleReducerEvent.Failed -> {
+                    state.copy(isLoading = false, error = event.error, canRetry = event.canRetry)
+                }
+
+                AddScheduleReducerEvent.ErrorConsumed -> {
+                    state.copy(error = null, canRetry = false)
+                }
+
+                AddScheduleReducerEvent.SavedConsumed -> {
+                    state.copy(isSaved = false)
+                }
+            }
+
+        private fun loadForEdit(scheduleId: String) {
+            dispatch(AddScheduleReducerEvent.EditLoading)
+            viewModelScope.launch {
                 when (val result = scheduleRepository.getScheduleById(scheduleId)) {
                     is ScheduleRepository.ScheduleResult.Success -> {
                         val schedule = result.data
-                        val startCal =
-                            Calendar.getInstance().apply {
-                                time = schedule.startTime.toDate()
-                            }
-                        val endCal =
-                            schedule.endTime?.let { endTime ->
-                                Calendar.getInstance().apply {
-                                    time = endTime.toDate()
-                                }
-                            }
-
-                        _uiState.value =
-                            _uiState.value.copy(
-                                title = schedule.title,
-                                description = schedule.description,
-                                selectedTime = startCal,
-                                endTime = endCal,
-                                recurring = schedule.recurring,
-                                recurringType = schedule.recurringType ?: "daily",
-                                isLoading = false,
-                                canSave = schedule.title.isNotBlank(),
-                                editingSchedule = schedule, // <-- store full schedule
-                            )
+                        dispatch(
+                            AddScheduleReducerEvent.EditLoaded(
+                                schedule = schedule,
+                                startTime = Calendar.getInstance().apply { time = schedule.startTime.toDate() },
+                                endTime = schedule.endTime?.let { end -> Calendar.getInstance().apply { time = end.toDate() } },
+                            ),
+                        )
                     }
 
                     is ScheduleRepository.ScheduleResult.Error -> {
-                        _uiState.value =
-                            _uiState.value.copy(
-                                isLoading = false,
-                                error = result.error,
-                                canRetry = true,
-                            )
+                        dispatch(AddScheduleReducerEvent.Failed(result.error, canRetry = false))
                     }
                 }
             }
         }
 
-        fun saveSchedule(context: Context) {
-            val currentTitle = _uiState.value.title.trim()
-
-            // Validation (outside coroutine)
-            when {
-                currentTitle.isBlank() -> {
-                    _uiState.value =
-                        _uiState.value.copy(
-                            error = AppError.GeneralError("할 일을 입력해주세요"),
-                        )
-                    return
-                }
-
-                currentTitle.length > 100 -> {
-                    _uiState.value =
-                        _uiState.value.copy(
-                            error = AppError.GeneralError("제목이 너무 깁니다 (최대 100자)"),
-                        )
-                    return
-                }
-
-                _uiState.value.endTime?.let { end ->
-                    end.timeInMillis <= _uiState.value.selectedTime.timeInMillis
-                } == true -> {
-                    _uiState.value =
-                        _uiState.value.copy(
-                            error = AppError.GeneralError("종료 시간은 시작 시간보다 늦어야 합니다"),
-                        )
-                    return
-                }
+        private fun save() {
+            val state = currentState
+            val title = state.title.trim()
+            validationError(state, title)?.let { message ->
+                dispatch(AddScheduleReducerEvent.Failed(AppError.GeneralError(message), canRetry = false))
+                return
             }
+            dispatch(AddScheduleReducerEvent.Saving)
 
+            val schedule = state.toSchedule(title)
             viewModelScope.launch {
-                _uiState.value =
-                    _uiState.value.copy(
-                        isLoading = true,
-                        error = null,
-                        canRetry = false,
-                    )
-
-                try {
-                    Log.d("AddSchedule", "일정 저장 시작: $currentTitle")
-
-                    val schedule =
-                        if (_uiState.value.isEditMode) {
-                            // Use original schedule as base, update only changed fields
-                            val original = _uiState.value.editingSchedule!!
-                            original.copy(
-                                title = currentTitle,
-                                description = _uiState.value.description.trim(),
-                                startTime = Timestamp(_uiState.value.selectedTime.time),
-                                endTime = _uiState.value.endTime?.let { Timestamp(it.time) },
-                                recurring = _uiState.value.recurring,
-                                recurringType = if (_uiState.value.recurring) _uiState.value.recurringType else null,
-                            )
-                        } else {
-                            Schedule(
-                                title = currentTitle,
-                                description = _uiState.value.description.trim(),
-                                startTime = Timestamp(_uiState.value.selectedTime.time),
-                                endTime = _uiState.value.endTime?.let { Timestamp(it.time) },
-                                recurring = _uiState.value.recurring,
-                                recurringType = if (_uiState.value.recurring) _uiState.value.recurringType else null,
-                            )
-                        }
-
-                    val result =
-                        if (_uiState.value.isEditMode) {
-                            Log.d("AddSchedule", "일정 수정 모드")
-                            scheduleRepository.updateSchedule(schedule)
-                        } else {
-                            Log.d("AddSchedule", "일정 추가 모드")
-                            scheduleRepository.addSchedule(schedule)
-                        }
-
-                    when (result) {
-                        is ScheduleRepository.ScheduleResult.Success -> {
-                            Log.d("AddSchedule", "저장 성공")
-                            requestExactAlarmPermissionIfNeeded(context)
-                            try {
-                                ScheduleAlarmHelper.scheduleAlarm(context, schedule)
-                                Log.d("AddSchedule", "알람 예약 성공")
-                            } catch (e: Exception) {
-                                Log.e("AddSchedule", "알람 예약 실패", e)
-                            }
-                            _uiState.value =
-                                _uiState.value.copy(
-                                    isLoading = false,
-                                    isSuccess = true,
-                                )
-                        }
-
-                        is ScheduleRepository.ScheduleResult.Error -> {
-                            Log.e("AddSchedule", "저장 실패: ${result.error.message}")
-                            _uiState.value =
-                                _uiState.value.copy(
-                                    isLoading = false,
-                                    error = result.error,
-                                    canRetry = true,
-                                )
-                        }
+                val result =
+                    if (state.isEditMode) {
+                        scheduleRepository.updateSchedule(schedule).map { schedule.id }
+                    } else {
+                        scheduleRepository.addSchedule(schedule)
                     }
-                } catch (e: Exception) {
-                    Log.e("AddSchedule", "예상치 못한 저장 실패", e)
-                    _uiState.value =
-                        _uiState.value.copy(
-                            isLoading = false,
-                            error = AppError.GeneralError("일정 저장 중 문제가 발생했습니다"),
-                            canRetry = true,
-                        )
+                when (result) {
+                    is ScheduleRepository.ScheduleResult.Success -> {
+                        // 새 일정은 Firestore 가 준 ID 로 알람을 건다. 빈 ID 로 걸면 모든 새 일정이 같은 요청 코드를 쓴다.
+                        runCatching { alarmScheduler.schedule(schedule.copy(id = result.data)) }
+                            .onFailure { Log.e(TAG, "알람 예약 실패", it) }
+                        dispatch(AddScheduleReducerEvent.Saved)
+                    }
+
+                    is ScheduleRepository.ScheduleResult.Error -> {
+                        Log.e(TAG, "저장 실패: ${result.error.message}")
+                        dispatch(AddScheduleReducerEvent.Failed(result.error, canRetry = true))
+                    }
                 }
             }
         }
 
-        fun clearError() {
-            _uiState.value = _uiState.value.copy(error = null, canRetry = false)
+        private fun validationError(
+            state: AddScheduleUiState,
+            title: String,
+        ): String? =
+            when {
+                title.isBlank() -> {
+                    "할 일을 입력해주세요"
+                }
+
+                title.length > MAX_TITLE_LENGTH -> {
+                    "제목이 너무 깁니다 (최대 ${MAX_TITLE_LENGTH}자)"
+                }
+
+                state.endTime != null && state.endTime.timeInMillis <= state.selectedTime.timeInMillis -> {
+                    "종료 시간은 시작 시간보다 늦어야 합니다"
+                }
+
+                else -> {
+                    null
+                }
+            }
+
+        private fun AddScheduleUiState.toSchedule(title: String): Schedule {
+            val base = if (isEditMode) editingSchedule ?: Schedule() else Schedule()
+            return base.copy(
+                title = title,
+                description = description.trim(),
+                startTime = Timestamp(selectedTime.time),
+                endTime = endTime?.let { Timestamp(it.time) },
+                recurring = recurring,
+                recurringType = if (recurring) recurringType else null,
+            )
         }
 
-        fun retryLastAction(context: Context) {
-            clearError()
-            saveSchedule(context)
+        private fun <T, R> ScheduleRepository.ScheduleResult<T>.map(transform: (T) -> R): ScheduleRepository.ScheduleResult<R> =
+            when (this) {
+                is ScheduleRepository.ScheduleResult.Success -> ScheduleRepository.ScheduleResult.Success(transform(data))
+                is ScheduleRepository.ScheduleResult.Error -> this
+            }
+
+        private companion object {
+            const val TAG = "AddScheduleViewModel"
         }
     }
+
+private fun Calendar.copyOf(): Calendar = Calendar.getInstance().apply { timeInMillis = this@copyOf.timeInMillis }

--- a/feature/addschedule/src/test/java/com/example/slowclock/ui/addschedule/AddScheduleViewModelTest.kt
+++ b/feature/addschedule/src/test/java/com/example/slowclock/ui/addschedule/AddScheduleViewModelTest.kt
@@ -1,0 +1,158 @@
+package com.example.slowclock.ui.addschedule
+
+import com.example.slowclock.core.alarm.AlarmScheduler
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.data.remote.repository.ScheduleRepository
+import com.example.slowclock.util.AppError
+import com.google.firebase.Timestamp
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Calendar
+import java.util.Date
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddScheduleViewModelTest {
+    private val scheduleRepository = mockk<ScheduleRepository>()
+    private val alarmScheduler = mockk<AlarmScheduler>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        justRun { alarmScheduler.schedule(any()) }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = AddScheduleViewModel(scheduleRepository, alarmScheduler)
+
+    @Test
+    fun `제목이 비어 있으면 저장하지 않고 안내한다`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(AddScheduleIntent.Save)
+
+            assertEquals(
+                "할 일을 입력해주세요",
+                viewModel.uiState.value.error
+                    ?.message,
+            )
+            assertFalse(viewModel.uiState.value.canRetry)
+            coVerify(exactly = 0) { scheduleRepository.addSchedule(any()) }
+        }
+
+    @Test
+    fun `종료 시각이 시작보다 빠르면 저장하지 않는다`() =
+        runTest {
+            val viewModel = createViewModel()
+            val start = Calendar.getInstance()
+            val end = (start.clone() as Calendar).apply { add(Calendar.HOUR_OF_DAY, -1) }
+
+            viewModel.onIntent(AddScheduleIntent.UpdateTitle("약 먹기"))
+            viewModel.onIntent(AddScheduleIntent.UpdateTime(start))
+            viewModel.onIntent(AddScheduleIntent.UpdateEndTime(end))
+            viewModel.onIntent(AddScheduleIntent.Save)
+
+            assertEquals(
+                "종료 시간은 시작 시간보다 늦어야 합니다",
+                viewModel.uiState.value.error
+                    ?.message,
+            )
+            coVerify(exactly = 0) { scheduleRepository.addSchedule(any()) }
+        }
+
+    @Test
+    fun `새 일정을 저장하면 Firestore 가 준 ID 로 알람을 걸고 저장 신호를 낸다`() =
+        runTest {
+            coEvery { scheduleRepository.addSchedule(any()) } returns ScheduleRepository.ScheduleResult.Success("new-id")
+            val scheduled = slot<Schedule>()
+            justRun { alarmScheduler.schedule(capture(scheduled)) }
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(AddScheduleIntent.UpdateTitle("  약 먹기 "))
+            viewModel.onIntent(AddScheduleIntent.UpdateDescription("식후 30분"))
+            viewModel.onIntent(AddScheduleIntent.Save)
+
+            val state = viewModel.uiState.value
+            assertTrue(state.isSaved)
+            assertFalse(state.isLoading)
+            assertEquals("new-id", scheduled.captured.id)
+            assertEquals("약 먹기", scheduled.captured.title)
+            assertEquals("식후 30분", scheduled.captured.description)
+
+            viewModel.onIntent(AddScheduleIntent.ConsumeSaved)
+            assertFalse(viewModel.uiState.value.isSaved)
+        }
+
+    @Test
+    fun `수정 모드는 기존 일정을 불러오고 같은 ID 로 갱신한다`() =
+        runTest {
+            val existing =
+                Schedule(
+                    id = "s1",
+                    title = "산책",
+                    description = "공원",
+                    startTime = Timestamp(Date(1_800_000_000_000L)),
+                    recurring = true,
+                    recurringType = "weekly",
+                )
+            coEvery { scheduleRepository.getScheduleById("s1") } returns ScheduleRepository.ScheduleResult.Success(existing)
+            val updated = slot<Schedule>()
+            coEvery { scheduleRepository.updateSchedule(capture(updated)) } returns ScheduleRepository.ScheduleResult.Success(Unit)
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+            val loaded = viewModel.uiState.value
+            assertTrue(loaded.isEditMode)
+            assertEquals("산책", loaded.title)
+            assertEquals("weekly", loaded.recurringType)
+            assertEquals(1_800_000_000_000L, loaded.selectedTime.timeInMillis)
+
+            viewModel.onIntent(AddScheduleIntent.UpdateTitle("긴 산책"))
+            viewModel.onIntent(AddScheduleIntent.Save)
+
+            assertEquals("s1", updated.captured.id)
+            assertEquals("긴 산책", updated.captured.title)
+            assertTrue(viewModel.uiState.value.isSaved)
+            verify(exactly = 1) { alarmScheduler.schedule(match { it.id == "s1" }) }
+        }
+
+    @Test
+    fun `저장이 실패하면 재시도 가능한 오류를 두고 Retry 가 다시 저장한다`() =
+        runTest {
+            coEvery { scheduleRepository.addSchedule(any()) } returns ScheduleRepository.ScheduleResult.Error(AppError.NetworkError) andThen
+                ScheduleRepository.ScheduleResult.Success("new-id")
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(AddScheduleIntent.UpdateTitle("약 먹기"))
+            viewModel.onIntent(AddScheduleIntent.Save)
+            assertEquals(AppError.NetworkError, viewModel.uiState.value.error)
+            assertTrue(viewModel.uiState.value.canRetry)
+
+            viewModel.onIntent(AddScheduleIntent.Retry)
+
+            assertNull(viewModel.uiState.value.error)
+            assertTrue(viewModel.uiState.value.isSaved)
+            coVerify(exactly = 2) { scheduleRepository.addSchedule(any()) }
+        }
+}

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainViewModel.kt
@@ -2,6 +2,7 @@ package com.example.slowclock.ui.main
 
 import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.example.slowclock.core.alarm.AlarmScheduler
 import com.example.slowclock.data.model.Schedule
 import com.example.slowclock.data.remote.repository.AuthRepository
 import com.example.slowclock.data.remote.repository.ScheduleRepository
@@ -34,6 +35,7 @@ class MainViewModel
         private val userRepository: UserRepository,
         private val authRepository: AuthRepository,
         private val settingsRepository: SettingsRepository,
+        private val alarmScheduler: AlarmScheduler,
     ) : MviViewModel<MainIntent, MainUiState, MainReducerEvent>(MainUiState()) {
         private var scheduleJob: Job? = null
 
@@ -232,6 +234,7 @@ class MainViewModel
             viewModelScope.launch {
                 when (val result = scheduleRepository.deleteSchedule(schedule.id)) {
                     is ScheduleRepository.ScheduleResult.Success -> {
+                        runCatching { alarmScheduler.cancel(schedule) }.onFailure { Log.e(TAG, "알람 취소 실패", it) }
                         dispatch(MainReducerEvent.Deleted(schedule.id, System.currentTimeMillis()))
                     }
 

--- a/feature/main/src/test/java/com/example/slowclock/ui/main/MainViewModelTest.kt
+++ b/feature/main/src/test/java/com/example/slowclock/ui/main/MainViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.example.slowclock.ui.main
 
+import com.example.slowclock.core.alarm.AlarmScheduler
 import com.example.slowclock.data.model.Schedule
 import com.example.slowclock.data.remote.repository.AuthRepository
 import com.example.slowclock.data.remote.repository.ScheduleRepository
@@ -11,6 +12,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +37,7 @@ class MainViewModelTest {
     private val userRepository = mockk<UserRepository>()
     private val authRepository = mockk<AuthRepository>()
     private val settingsRepository = mockk<SettingsRepository>()
+    private val alarmScheduler = mockk<AlarmScheduler>(relaxed = true)
 
     private val todaySchedules = MutableStateFlow<List<Schedule>>(emptyList())
     private val shareCode = MutableStateFlow<String?>(null)
@@ -58,7 +61,7 @@ class MainViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = MainViewModel(scheduleRepository, userRepository, authRepository, settingsRepository)
+    private fun createViewModel() = MainViewModel(scheduleRepository, userRepository, authRepository, settingsRepository, alarmScheduler)
 
     @Test
     fun `리스너가 낸 오늘 일정으로 상태를 채우고 지금 할 일을 고른다`() =
@@ -129,6 +132,7 @@ class MainViewModelTest {
             assertFalse(state.isLoading)
             assertEquals(listOf("s2"), state.todaySchedules.map { it.id })
             coVerify(exactly = 1) { scheduleRepository.deleteSchedule("s1") }
+            verify(exactly = 1) { alarmScheduler.cancel(match { it.id == "s1" }) }
         }
 
     @Test

--- a/feature/recommendation/build.gradle.kts
+++ b/feature/recommendation/build.gradle.kts
@@ -19,5 +19,4 @@ android {
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:model"))
-    implementation(libs.androidx.navigation.compose)
 }

--- a/feature/recommendation/src/main/java/com/example/slowclock/ui/recommendation/RecommendationScreen.kt
+++ b/feature/recommendation/src/main/java/com/example/slowclock/ui/recommendation/RecommendationScreen.kt
@@ -7,90 +7,88 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import com.example.slowclock.data.model.Recommendation
 import com.example.slowclock.ui.recommendation.components.ADHDRecommendation
 import com.example.slowclock.ui.recommendation.components.ElderlyRecommendation
 import com.example.slowclock.ui.recommendation.components.StudentRecommendation
 
+private enum class RecommendationGroup {
+    ELDERLY,
+    ADHD,
+    STUDENT,
+}
+
+private val allRecommendations =
+    listOf(
+        Recommendation("밥 먹기"),
+        Recommendation("잠 자기"),
+        Recommendation("약 먹기"),
+        Recommendation("병원 예약하기"),
+        Recommendation("운동하기"),
+        Recommendation("감정 일기 쓰기", "ADHD"),
+        Recommendation("회피 행동 돌아보기", "ADHD"),
+        Recommendation("명상하기", "ADHD"),
+        Recommendation("자습", "학생"),
+        Recommendation("공부량 확인", "학생"),
+        Recommendation("휴식하기", "학생"),
+        Recommendation("복습하기", "학생"),
+        Recommendation("햇빛 쬐기", "노인"),
+        Recommendation("일기 쓰기", "노인"),
+        Recommendation("노인정에서 교류하기", "노인"),
+        Recommendation("음악 감상하기", "노인"),
+        Recommendation("새로운 공부하기", "노인"),
+        Recommendation("사회봉사하기", "노인"),
+    )
+
+/**
+ * 일정 추천 화면. 서버 상태가 없어 ViewModel 을 두지 않는다. 고른 제목은 [onSelectRecommendation]
+ * 으로 넘기고, 어느 화면에 돌려줄지는 NavGraph 가 정한다.
+ */
 @Composable
 fun RecommendationScreen(
-    navController: NavController,
+    onSelectRecommendation: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val userInfo = remember { mutableStateOf("Elderly") }
-    val allRecommendation =
-        listOf(
-            Recommendation("밥 먹기"),
-            Recommendation("잠 자기"),
-            Recommendation("약 먹기"),
-            Recommendation("병원 예약하기"),
-            Recommendation("운동하기"),
-            Recommendation("감정 일기 쓰기", "ADHD"),
-            Recommendation("회피 행동 돌아보기", "ADHD"),
-            Recommendation("명상하기", "ADHD"),
-            Recommendation("자습", "학생"),
-            Recommendation("공부량 확인", "학생"),
-            Recommendation("휴식하기", "학생"),
-            Recommendation("복습하기", "학생"),
-            Recommendation("햇빛 쬐기", "노인"),
-            Recommendation("일기 쓰기", "노인"),
-            Recommendation("노인정에서 교류하기", "노인"),
-            Recommendation("음악 감상하기", "노인"),
-            Recommendation("새로운 공부하기", "노인"),
-            Recommendation("사회봉사하기", "노인"),
-        )
-    Column(modifier = Modifier.fillMaxSize()) {
+    var group by rememberSaveable { mutableStateOf(RecommendationGroup.ELDERLY) }
+
+    Column(modifier = modifier.fillMaxSize()) {
         Row(modifier = Modifier.padding(8.dp)) {
-            Button(onClick = { userInfo.value = "Elderly" }, modifier = Modifier.padding(4.dp)) {
+            Button(onClick = { group = RecommendationGroup.ELDERLY }, modifier = Modifier.padding(4.dp)) {
                 Text(text = "노인")
             }
-            Button(onClick = { userInfo.value = "ADHD" }, modifier = Modifier.padding(4.dp)) {
+            Button(onClick = { group = RecommendationGroup.ADHD }, modifier = Modifier.padding(4.dp)) {
                 Text(text = "ADHD")
             }
-            Button(onClick = { userInfo.value = "Student" }, modifier = Modifier.padding(4.dp)) {
+            Button(onClick = { group = RecommendationGroup.STUDENT }, modifier = Modifier.padding(4.dp)) {
                 Text(text = "학생")
             }
         }
 
-        when (userInfo.value) {
-            "Elderly" -> {
+        when (group) {
+            RecommendationGroup.ELDERLY -> {
                 ElderlyRecommendation(
-                    list = allRecommendation,
-                    onSelectRecommendation = { selectedTitle ->
-                        navController.previousBackStackEntry
-                            ?.savedStateHandle
-                            ?.set("initial_title", selectedTitle)
-                        navController.popBackStack()
-                    },
+                    list = allRecommendations,
+                    onSelectRecommendation = onSelectRecommendation,
                 )
             }
 
-            "ADHD" -> {
+            RecommendationGroup.ADHD -> {
                 ADHDRecommendation(
-                    list = allRecommendation,
-                    onSelectRecommendation = { selectedTitle ->
-                        navController.previousBackStackEntry
-                            ?.savedStateHandle
-                            ?.set("initial_title", selectedTitle)
-                        navController.popBackStack()
-                    },
+                    list = allRecommendations,
+                    onSelectRecommendation = onSelectRecommendation,
                 )
             }
 
-            else -> {
+            RecommendationGroup.STUDENT -> {
                 StudentRecommendation(
-                    list = allRecommendation,
-                    onSelectRecommendation = { selectedTitle ->
-                        navController.previousBackStackEntry
-                            ?.savedStateHandle
-                            ?.set("initial_title", selectedTitle)
-                        navController.popBackStack()
-                    },
+                    list = allRecommendations,
+                    onSelectRecommendation = onSelectRecommendation,
                 )
             }
         }


### PR DESCRIPTION
## 📌 Issues

Closes #55
Refs #53

## 📎 Work Description

- `AddScheduleViewModel` 을 `MviViewModel<AddScheduleIntent, AddScheduleUiState, AddScheduleReducerEvent>` 로 옮겼다. 폼 갱신은 `Intent.UpdateXxx` → `ReducerEvent.XxxChanged`, 저장은 `Saving` → `Saved`/`Failed`. 저장 완료는 `isSaved` 신호를 화면이 `ObserveSignal` 로 소비하고 `ConsumeSaved` 로 되돌린다. 화면은 `AddScheduleScreen(onNavigateBack, onNavigateToRecommendation, …)` / `internal fun AddScheduleContent(state, onIntent, …)` 2단이다.
- `core/alarm` 에 `AlarmScheduler`(`@ApplicationContext` 주입)를 두었다. ViewModel 이 `Context` 를 받지 않고, 메인 화면은 일정을 지울 때 알람도 함께 취소한다(예전에는 삭제해도 알람이 남았다).
- 새 일정의 알람을 Firestore 가 돌려준 ID 로 건다. 예전에는 저장 전 객체(ID 빈 문자열)로 걸어 모든 새 일정의 요청 코드가 같았고, 나중 일정이 앞 일정의 알람을 덮어썼다.
- 저장 직후의 정확한 알람 권한 요청은 지웠다. `MainActivity` 가 시작할 때 이미 요청한다.
- `RecommendationScreen` 은 `NavController` 대신 `onSelectRecommendation` 콜백을 받는다. `savedStateHandle["initial_title"]` 설정은 `AppNavigation` 이 한다. `feature/recommendation` 의 navigation 의존을 지웠다.
- `feature/addschedule` 의 `firebase-auth` 의존을 지우고 테스트 의존성을 넣었다.

단위 테스트 `AddScheduleViewModelTest` 5건: 빈 제목, 종료 시각 검증, 저장 성공(ID 로 알람), 수정 모드 로드·갱신, 실패 후 재시도. `MainViewModelTest` 에 삭제 시 알람 취소 검증을 더했다. 로컬 검증: `ktlintCheck`, `:feature:addschedule:testDebugUnitTest`, `:feature:main:testDebugUnitTest`, `:app:assembleDebug`, `:app:assembleRelease`, `:app:lintDebug`, `:app:testDebugUnitTest` 통과.

## 📷 Screenshot

화면 구성은 그대로다. 수정 모드로 불러오는 동안의 로딩 카드 문구가 "일정을 불러오는 중..." 으로 구분된다.

## 💬 To Reviewers

- 기기에서 확인할 것: 일정 추가 뒤 알람이 그 일정 시각에 울리는지, 일정 삭제 뒤 알람이 울리지 않는지.
- 남은 ViewModel 이 아닌 화면(`RecommendationScreen`·`SettingsScreen`)은 서버 상태가 없어 MVI 대상이 아니다.