### PR TITLE
fix: 의존성 그래프 제출을 --no-parallel 로 돌린다

### DIFF
--- a/.github/workflows/dependency-submission-trusted.yml
+++ b/.github/workflows/dependency-submission-trusted.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          additional-arguments: --no-configuration-cache --stacktrace
+          # dependency-graph 추출 플러그인은 org.gradle.parallel=true 에서 configurationMetrics 를
+          # 동시에 쓰다 "Can only append an element to the list once" 로 죽는다(#67, run 33955978958).
+          # 실패한 main snapshot 은 그 위에 올린 PR 의 dependency-review 를 재시도 창까지 굶긴다.
+          additional-arguments: --no-configuration-cache --no-parallel --stacktrace
           cache-provider: basic
           # 이 job 은 의존성만 해석하므로 저장할 build cache 산출물이 없다. 생략하면 액션
           # 기본값으로 저장까지 하는데, 그 엔트리는 build-cache-warm.yml 이 채우려는 것과

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -53,7 +53,10 @@ jobs:
       - name: Generate dependency graph artifact
         uses: gradle/actions/dependency-submission@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          additional-arguments: --no-configuration-cache --stacktrace
+          # dependency-graph 추출 플러그인은 org.gradle.parallel=true 에서 configurationMetrics 를
+          # 동시에 쓰다 "Can only append an element to the list once" 로 죽는다(#67, run 33955978958).
+          # 실패한 main snapshot 은 그 위에 올린 PR 의 dependency-review 를 재시도 창까지 굶긴다.
+          additional-arguments: --no-configuration-cache --no-parallel --stacktrace
           # 예외: job 간 전송용 — 제출 job 이 같은 run 안에서 소비한다 (#1400).
           artifact-retention-days: 1
           cache-provider: basic


### PR DESCRIPTION
## 📌 Issues

Closes #67

## 📎 Work Description

dependency-submission 을 쓰는 두 워크플로(main 의 Submit trusted branch dependency graph, PR 의 Generate PR dependency graph)의 Gradle 인자에 `--no-parallel` 을 더했다.

`gradle/actions/dependency-submission` 이 붙이는 dependency-graph 추출 플러그인은 `org.gradle.parallel=true` 에서 여러 프로젝트가 `configurationMetrics` 를 동시에 쓰다 죽는다. main `343c463` 의 [run 33955978958](https://github.com/1hyok/SlowClock/actions/runs/33955978958) 이 그렇게 실패했고, 그 결과 그 SHA 를 base 로 삼은 PR #63 의 dependency-review 가 base snapshot 0건 경고를 20분 재시도 창이 끝날 때까지 받다가 실패했다. 이 job 들은 의존성 해석만 하므로 병렬 실행의 이득이 거의 없다.

이미 실패해 비어 있던 `343c463` 의 snapshot 은 해당 run 을 재실행해 복구했다.

## 📷 Screenshot

CI 설정 변경이라 화면 없음.

## 💬 To Reviewers

- 앞으로 PR 의 dependency-review 가 취약점 없이 snapshot 경고만으로 실패하면 base SHA 의 trusted run 부터 확인하면 된다.
