### PR TITLE
chore: build-logic 컨벤션 플러그인으로 모듈 빌드 설정을 한 곳에 모은다

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,13 +2,11 @@ import com.google.firebase.appdistribution.gradle.firebaseAppDistribution
 import java.util.Properties
 
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.slowclock.android.application)
+    alias(libs.plugins.slowclock.android.hilt)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.compose.screenshot)
     alias(libs.plugins.firebase.app.distribution)
-    alias(libs.plugins.hilt)
-    alias(libs.plugins.ksp)
     id("com.google.gms.google-services")
 }
 
@@ -34,15 +32,12 @@ android {
     // namespace(R 클래스·소스 패키지)는 그대로 두고 applicationId 만 Play 등록용으로 바꾼다.
     // Play 는 com.example.* 패키지를 거부하며, Firebase Android 앱은 이 applicationId 로 등록돼 있다.
     namespace = "com.example.slowclock"
-    compileSdk = 36
 
     // Compose Preview Screenshot Testing (alpha) 활성화
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
 
     defaultConfig {
         applicationId = "com.ilhyok.slowclock"
-        minSdk = 32
-        targetSdk = 36
         versionCode = resolveSlowClockVersionCode(System.getenv(slowClockVersionCodeEnv))
         versionName = "1.0"
 
@@ -91,13 +86,6 @@ android {
             }
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
     buildFeatures {
         compose = true
     }
@@ -130,8 +118,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.navigation.compose)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.firebase.ui.auth)
     implementation(libs.volley)

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,52 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `kotlin-dsl`
+}
+
+group = "com.example.slowclock.buildlogic"
+
+// 컨벤션 플러그인은 Gradle 데몬 JVM(21)에서 돌지만 산출물은 17 로 맞춘다. AGP 8.13 의 최소 JDK 가 17 이다.
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    compileOnly(libs.android.gradlePlugin)
+    compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.compose.compiler.gradlePlugin)
+    compileOnly(libs.ksp.gradlePlugin)
+    compileOnly(libs.hilt.gradlePlugin)
+}
+
+gradlePlugin {
+    plugins {
+        register("androidApplication") {
+            id = "slowclock.android.application"
+            implementationClass = "AndroidApplicationConventionPlugin"
+        }
+        register("androidLibrary") {
+            id = "slowclock.android.library"
+            implementationClass = "AndroidLibraryConventionPlugin"
+        }
+        register("androidLibraryCompose") {
+            id = "slowclock.android.library.compose"
+            implementationClass = "AndroidLibraryComposeConventionPlugin"
+        }
+        register("androidHilt") {
+            id = "slowclock.android.hilt"
+            implementationClass = "AndroidHiltConventionPlugin"
+        }
+        register("androidFeature") {
+            id = "slowclock.android.feature"
+            implementationClass = "AndroidFeatureConventionPlugin"
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -1,0 +1,21 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.example.slowclock.buildlogic.TARGET_SDK
+import com.example.slowclock.buildlogic.configureKotlinAndroid
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/** `:app`. 공통 SDK·JVM 설정에 targetSdk 를 더한다. 서명·버전·배포 설정은 앱 빌드 파일에 남긴다. */
+class AndroidApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.android.application")
+            pluginManager.apply("org.jetbrains.kotlin.android")
+
+            extensions.configure<ApplicationExtension> {
+                configureKotlinAndroid(this)
+                defaultConfig.targetSdk = TARGET_SDK
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -1,0 +1,31 @@
+import com.example.slowclock.buildlogic.library
+import com.example.slowclock.buildlogic.libs
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.project
+
+/**
+ * `:feature:*`. Compose 라이브러리 + Hilt 에 화면 모듈이 늘 쓰는 의존을 더한다.
+ * `:core:ui` 가 Compose·테마·MVI 베이스를, `:core:data` 가 Repository 를 노출한다.
+ */
+class AndroidFeatureConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("slowclock.android.library.compose")
+            pluginManager.apply("slowclock.android.hilt")
+
+            dependencies {
+                add("implementation", project(":core:ui"))
+                add("implementation", project(":core:data"))
+                add("implementation", libs.library("androidx-hilt-navigation-compose"))
+                add("implementation", libs.library("androidx-lifecycle-viewmodel-compose"))
+                add("implementation", libs.library("androidx-lifecycle-runtime-compose"))
+
+                add("testImplementation", libs.library("junit"))
+                add("testImplementation", libs.library("mockk"))
+                add("testImplementation", libs.library("kotlinx-coroutines-test"))
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -1,0 +1,20 @@
+import com.example.slowclock.buildlogic.library
+import com.example.slowclock.buildlogic.libs
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+/** Hilt + KSP. `@Inject` 생성자·`@HiltViewModel`·`@Module` 이 있는 모듈이 쓴다. */
+class AndroidHiltConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.google.devtools.ksp")
+            pluginManager.apply("com.google.dagger.hilt.android")
+
+            dependencies {
+                add("implementation", libs.library("hilt-android"))
+                add("ksp", libs.library("hilt-compiler"))
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -1,0 +1,18 @@
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/** Compose 를 쓰는 라이브러리. Compose 의존은 `:core:ui` 가 api 로 노출하므로 여기서는 플러그인만 켠다. */
+class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("slowclock.android.library")
+            pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
+
+            extensions.configure<LibraryExtension> {
+                buildFeatures.compose = true
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,0 +1,20 @@
+import com.android.build.api.dsl.LibraryExtension
+import com.example.slowclock.buildlogic.configureKotlinAndroid
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/** `:core:*`·`:feature:*` 공통. JVM 단위 테스트에서 android.util.Log 같은 스텁이 예외를 던지지 않게 한다. */
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.android.library")
+            pluginManager.apply("org.jetbrains.kotlin.android")
+
+            extensions.configure<LibraryExtension> {
+                configureKotlinAndroid(this)
+                testOptions.unitTests.isReturnDefaultValues = true
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/example/slowclock/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/example/slowclock/buildlogic/KotlinAndroid.kt
@@ -1,0 +1,31 @@
+package com.example.slowclock.buildlogic
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+
+/** 앱·라이브러리 공통 SDK·JVM 설정. 숫자는 여기 한 곳에만 둔다. */
+internal const val COMPILE_SDK = 36
+internal const val MIN_SDK = 32
+internal const val TARGET_SDK = 36
+
+internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, *, *, *, *, *>) {
+    commonExtension.apply {
+        compileSdk = COMPILE_SDK
+        defaultConfig {
+            minSdk = MIN_SDK
+        }
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_11
+            targetCompatibility = JavaVersion.VERSION_11
+        }
+    }
+    extensions.configure<KotlinAndroidProjectExtension> {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/example/slowclock/buildlogic/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/example/slowclock/buildlogic/ProjectExtensions.kt
@@ -1,0 +1,12 @@
+package com.example.slowclock.buildlogic
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+/** 루트 `gradle/libs.versions.toml` 의 카탈로그. 컨벤션 플러그인은 좌표를 직접 적지 않고 여기서 찾는다. */
+internal val Project.libs: VersionCatalog
+    get() = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+internal fun VersionCatalog.library(alias: String) = findLibrary(alias).get()

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,23 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/core/alarm/build.gradle.kts
+++ b/core/alarm/build.gradle.kts
@@ -1,24 +1,10 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.hilt)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.slowclock.android.library)
+    alias(libs.plugins.slowclock.android.hilt)
 }
 
 android {
     namespace = "com.example.slowclock.core.alarm"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 32
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {
@@ -28,6 +14,4 @@ dependencies {
     implementation(libs.firebase.messaging)
     implementation(libs.firebase.auth)
     implementation(libs.volley)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
 }

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,22 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.slowclock.android.library)
 }
 
 android {
     namespace = "com.example.slowclock.core.common"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 32
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,24 +1,10 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.hilt)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.slowclock.android.library)
+    alias(libs.plugins.slowclock.android.hilt)
 }
 
 android {
     namespace = "com.example.slowclock.core.data"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 32
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {
@@ -27,8 +13,4 @@ dependencies {
 
     implementation(libs.firebase.auth)
     implementation(libs.firebase.messaging)
-
-    // Hilt: @Inject 생성자 Repository 의 Factory 가 본 모듈에서 생성되도록
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
 }

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -1,22 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.slowclock.android.library)
 }
 
 android {
     namespace = "com.example.slowclock.core.model"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 32
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
 }
 
 dependencies {

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,26 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.slowclock.android.library.compose)
 }
 
 android {
     namespace = "com.example.slowclock.core.ui"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 32
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
-    buildFeatures {
-        compose = true
-    }
 }
 
 dependencies {

--- a/feature/addschedule/build.gradle.kts
+++ b/feature/addschedule/build.gradle.kts
@@ -1,48 +1,11 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.hilt)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.slowclock.android.feature)
 }
 
 android {
     namespace = "com.example.slowclock.feature.addschedule"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 32
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
-    buildFeatures {
-        compose = true
-    }
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
 }
 
 dependencies {
-    implementation(project(":core:ui"))
-    implementation(project(":core:data"))
-    implementation(project(":core:model"))
-    implementation(project(":core:common"))
     implementation(project(":core:alarm"))
-
-    implementation(libs.androidx.hilt.navigation.compose)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.lifecycle.runtime.compose)
-
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
-    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -1,50 +1,11 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.hilt)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.slowclock.android.feature)
 }
 
 android {
     namespace = "com.example.slowclock.feature.main"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 32
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
-    buildFeatures {
-        compose = true
-    }
-    testOptions {
-        // ViewModel 의 android.util.Log 호출이 JVM 단위 테스트에서 예외를 던지지 않도록 한다.
-        unitTests.isReturnDefaultValues = true
-    }
 }
 
 dependencies {
-    implementation(project(":core:ui"))
-    implementation(project(":core:data"))
-    implementation(project(":core:model"))
-    implementation(project(":core:common"))
     implementation(project(":core:alarm"))
-
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.hilt.navigation.compose)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.lifecycle.runtime.compose)
-
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
-    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/feature/profile/build.gradle.kts
+++ b/feature/profile/build.gradle.kts
@@ -1,33 +1,7 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.hilt)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.slowclock.android.feature)
 }
 
 android {
     namespace = "com.example.slowclock.feature.profile"
-    compileSdk = 35
-    defaultConfig { minSdk = 32 }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions { jvmTarget = "11" }
-    buildFeatures { compose = true }
-}
-
-dependencies {
-    implementation(project(":core:ui"))
-    implementation(project(":core:data"))
-    implementation(libs.androidx.hilt.navigation.compose)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.lifecycle.runtime.compose)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
-    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/feature/recommendation/build.gradle.kts
+++ b/feature/recommendation/build.gradle.kts
@@ -1,22 +1,11 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.slowclock.android.library.compose)
 }
 
 android {
     namespace = "com.example.slowclock.feature.recommendation"
-    compileSdk = 35
-    defaultConfig { minSdk = 32 }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions { jvmTarget = "11" }
-    buildFeatures { compose = true }
 }
 
 dependencies {
     implementation(project(":core:ui"))
-    implementation(project(":core:model"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,4 +83,10 @@ compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "scr
 firebase-app-distribution = { id = "com.google.firebase.appdistribution", version.ref = "firebaseAppDistribution" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+# build-logic 컨벤션 플러그인 (포함 빌드라 버전이 없다)
+slowclock-android-application = { id = "slowclock.android.application" }
+slowclock-android-library = { id = "slowclock.android.library" }
+slowclock-android-library-compose = { id = "slowclock.android.library.compose" }
+slowclock-android-hilt = { id = "slowclock.android.hilt" }
+slowclock-android-feature = { id = "slowclock.android.feature" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google {
             content {


### PR DESCRIPTION
## 📌 Issues

Closes #25
Refs #53

## 📎 Work Description

모듈마다 반복하던 compileSdk·minSdk·JVM 11·Compose·Hilt/KSP 배선을 포함 빌드 `build-logic` 의 컨벤션 플러그인 다섯 개로 모았다. 방식은 Now in Android 의 `build-logic` 구성을 따랐다(https://github.com/android/nowinandroid/tree/main/build-logic).

- `slowclock.android.application`: `com.android.application` + Kotlin, 공통 SDK·JVM 설정에 targetSdk 를 더한다. 서명·버전·배포 설정은 앱 빌드 파일에 남긴다.
- `slowclock.android.library`: `com.android.library` + Kotlin, 공통 SDK·JVM 설정, JVM 단위 테스트의 `isReturnDefaultValues = true`.
- `slowclock.android.library.compose`: 위에 Compose 컴파일러 플러그인과 `buildFeatures.compose`.
- `slowclock.android.hilt`: KSP + Hilt 플러그인과 `hilt-android`·`hilt-compiler` 의존.
- `slowclock.android.feature`: Compose 라이브러리 + Hilt 에 `:core:ui`·`:core:data`·hilt-navigation-compose·lifecycle·테스트 의존.

SDK 숫자(compileSdk 36 / minSdk 32 / targetSdk 36)는 `build-logic/convention/.../KotlinAndroid.kt` 한 곳에만 있다. 플러그인 좌표(AGP·KGP·Compose 컴파일러·KSP·Hilt)는 카탈로그의 `*-gradlePlugin` 라이브러리로 두고 컨벤션 모듈이 `compileOnly` 로 쓴다. 모듈 빌드 파일은 네임스페이스와 모듈 고유 의존만 남아 10~25줄이 됐고, 루트 빌드 파일의 플러그인 목록과 `kotlinOptions` 블록은 사라졌다.

`:app` 의 Hilt 의존(`hilt-android`·`hilt-compiler`)도 컨벤션 플러그인이 넣으므로 앱 빌드 파일에서 지웠다. #63 과 겹친 `app/build.gradle.kts` 는 main 을 합치며 정리했다.

로컬 검증: `ktlintCheck`, `:app:assembleDebug`, `testDebugUnitTest`, `:app:lintDebug`, `:app:bundleRelease` 통과. `:app:validateScreenshotTest` 는 baseline 이 CI 컨테이너에서 만들어져 macOS 렌더와 어긋나므로 CI 결과를 본다.

## 📷 Screenshot

동작 변경 없음.

## 💬 To Reviewers

- 컨벤션 플러그인은 AGP 8.13 의 `CommonExtension<*, *, *, *, *, *>` 와 `KotlinAndroidProjectExtension` 을 쓴다. AGP 9 내장 Kotlin 으로 옮기는 #37 에서 이 두 군데를 AGP 9 DSL 에 맞춘다.
