### PR TITLE
fix: main 의존성 스냅샷 실행을 취소하지 않는다

### DIFF
--- a/.github/workflows/dependency-submission-trusted.yml
+++ b/.github/workflows/dependency-submission-trusted.yml
@@ -8,8 +8,11 @@ on:
     branches: [main]
 
 concurrency:
+  # SHA 마다 snapshot 이 있어야 그 SHA 를 base 로 삼은 PR 의 dependency-review 가 비교를 한다.
+  # 진행 중인 실행을 취소하면 그 커밋의 snapshot 이 비고, 그 위에 올린 PR 이 base 0건 경고로
+  # 재시도 창(1200초)을 다 쓰고 실패한다(#72, run 33958807941). 겹쳐 도는 비용이 더 싸다.
   group: trusted-branch-dependency-submission-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## 📌 Issues

Closes #72

## 📎 Work Description

main 의 Submit trusted branch dependency graph 워크플로에서 `cancel-in-progress` 를 `false` 로 바꿨다.

concurrency 그룹이 `github.ref` 라 main 에 커밋이 연달아 들어오면 앞 커밋의 snapshot 제출이 취소된다. 2026-09-05 `d94ba75` 의 [run 33958807941](https://github.com/1hyok/SlowClock/actions/runs/33958807941) 이 8초 뒤 들어온 `7decf73` 때문에 취소됐고, 그 SHA 를 base 로 삼은 PR 의 dependency-review 가 base snapshot 0건 경고를 재시도 창(1200초)이 끝날 때까지 받다가 실패했다. #67 에서 고친 병렬 크래시와 증상이 같고 원인만 다르다.

3분짜리 job 이 몇 개 겹쳐 도는 비용보다 PR 이 20분씩 굶는 비용이 크다. 취소돼 비어 있던 `d94ba75` 의 snapshot 은 해당 run 을 재실행해 복구했다.

로컬 검증: `node --test .github/scripts/*.test.mjs`(240 통과), `scripts/repository-quality.sh` 통과.

## 📷 Screenshot

CI 설정 변경이라 화면 없음.

## 💬 To Reviewers

- PR 쪽 Generate PR dependency graph 는 PR 번호로 그룹을 잡으므로 취소돼도 새 실행이 같은 head SHA 를 덮는다. 그래서 이 설정은 main 워크플로에만 넣었다.
