### PR TITLE
fix: 알람 전체화면이 predictive back 에 닫히지 않게 한다

### DIFF
--- a/core/alarm/src/main/java/com/example/slowclock/ui/alarm/AlarmFullScreenActivity.kt
+++ b/core/alarm/src/main/java/com/example/slowclock/ui/alarm/AlarmFullScreenActivity.kt
@@ -4,12 +4,15 @@ import android.app.Activity
 import android.media.MediaPlayer
 import android.media.RingtoneManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.view.WindowManager
 import android.widget.Button
 import android.widget.TextView
+import android.window.OnBackInvokedCallback
+import android.window.OnBackInvokedDispatcher
 import com.example.slowclock.core.alarm.R
 import java.text.SimpleDateFormat
 import java.util.*
@@ -18,6 +21,11 @@ class AlarmFullScreenActivity : Activity() {
     private var mediaPlayer: MediaPlayer? = null
     private val timeHandler = Handler(Looper.getMainLooper())
     private lateinit var timeRunnable: Runnable
+
+    // 알람은 닫기 버튼으로만 끈다. targetSdk 36 부터 predictive back 이 기본이라
+    // API 33 이상에서는 onBackPressed 가 불리지 않으므로 여기서 제스처를 삼킨다.
+    // https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture
+    private var backGestureCallback: OnBackInvokedCallback? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,6 +62,15 @@ class AlarmFullScreenActivity : Activity() {
 
         // 알람 소리 재생
         playAlarmSound()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val callback = OnBackInvokedCallback { }
+            onBackInvokedDispatcher.registerOnBackInvokedCallback(
+                OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+                callback,
+            )
+            backGestureCallback = callback
+        }
     }
 
     private fun updateCurrentTime(timeTextView: TextView) {
@@ -100,8 +117,14 @@ class AlarmFullScreenActivity : Activity() {
         super.onDestroy()
         stopAlarmSound()
         timeHandler.removeCallbacks(timeRunnable)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            backGestureCallback?.let(onBackInvokedDispatcher::unregisterOnBackInvokedCallback)
+            backGestureCallback = null
+        }
     }
 
+    // API 32 기기용. 33 이상은 위의 OnBackInvokedCallback 이 대신 막는다.
+    @Deprecated("API 33 미만 기기 전용", ReplaceWith(""))
     override fun onBackPressed() {
         // 사용자가 명시적으로 닫기 버튼을 눌러야 함
     }


### PR DESCRIPTION
## 📌 Issues

Closes #65

## 📎 Work Description

알람 전체화면이 뒤로가기 제스처 한 번에 닫히던 문제를 고쳤다.

`AlarmFullScreenActivity` 는 사용자가 닫기 버튼을 누를 때만 알람이 꺼지도록 `onBackPressed()` 를 빈 구현으로 재정의해 왔다. 그런데 targetSdk 36 부터 predictive back 이 기본으로 켜져 API 33 이상 기기에서는 그 재정의가 호출되지 않는다. 뒤로가기 제스처가 그대로 Activity 를 끝내고 `onDestroy` 가 소리를 멈춘다.

- `onBackInvokedDispatcher.registerOnBackInvokedCallback(PRIORITY_DEFAULT, …)` 에 빈 콜백을 등록해 제스처를 삼키고 `onDestroy` 에서 해제한다. 근거: [predictive back 가이드](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture)
- minSdk 가 32 라 API 32 기기에서는 기존 `onBackPressed` 재정의가 그대로 막는다. 그래서 두 경로를 함께 둔다.
- AndroidX `OnBackPressedDispatcher` 를 쓰려면 이 Activity 를 `ComponentActivity` 로 바꿔야 한다. 알람 화면은 Compose 가 아닌 XML 레이아웃 하나짜리이고 `singleInstance`·`showOnLockScreen` 로 잠금화면 위에 뜨는 특수한 화면이라, 이번에는 플랫폼 API 만 쓰고 상속 구조는 건드리지 않았다.

로컬 검증: `ktlintCheck`, `:app:assembleDebug`, `:app:lintDebug`, `testDebugUnitTest` 통과.

## 📷 Screenshot

화면 변화 없음. 뒤로가기 제스처에 반응하지 않는 것이 기대 동작이다.

## 💬 To Reviewers

- `docs/play-release.md` 의 predictive back 문장은 #37 에서 이 이슈를 가리키도록 고쳐 두었다.
