### PR TITLE
chore: Firestore 오프라인 캐시 설정을 FirebaseModule 로 옮긴다

### DIFF
--- a/app/src/main/java/com/example/slowclock/SlowClockApplication.kt
+++ b/app/src/main/java/com/example/slowclock/SlowClockApplication.kt
@@ -1,26 +1,11 @@
 package com.example.slowclock
 
 import android.app.Application
-import com.google.firebase.FirebaseApp
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.FirebaseFirestoreSettings
 import dagger.hilt.android.HiltAndroidApp
 
+/**
+ * Firebase 초기화는 google-services 플러그인이 넣는 FirebaseInitProvider 가 앱 시작 시 한다.
+ * Firestore 오프라인 캐시 설정은 인스턴스를 제공하는 `FirebaseModule` 이 맡는다.
+ */
 @HiltAndroidApp
-class SlowClockApplication : Application() {
-    override fun onCreate() {
-        super.onCreate()
-
-        // Firebase 초기화
-        FirebaseApp.initializeApp(this)
-
-        // Firestore 설정
-        val firestore = FirebaseFirestore.getInstance()
-        val settings =
-            FirebaseFirestoreSettings
-                .Builder()
-                .setPersistenceEnabled(true) // 오프라인 지원 활성화
-                .build()
-        firestore.firestoreSettings = settings
-    }
-}
+class SlowClockApplication : Application()

--- a/core/data/src/main/java/com/example/slowclock/data/di/FirebaseModule.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/di/FirebaseModule.kt
@@ -2,6 +2,8 @@ package com.example.slowclock.data.di
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreSettings
+import com.google.firebase.firestore.PersistentCacheSettings
 import com.google.firebase.messaging.FirebaseMessaging
 import dagger.Module
 import dagger.Provides
@@ -13,7 +15,8 @@ import javax.inject.Singleton
  * Firebase 진입점을 Hilt 로 제공한다. Repository 는 `getInstance()` 를 직접 부르지 않고 생성자로
  * 받는다. 테스트에서는 이 모듈을 `@TestInstallIn` 으로 바꾸거나 생성자에 fake 를 넣는다.
  *
- * Firestore 오프라인 캐시 같은 전역 설정은 `SlowClockApplication` 이 앱 시작 시 한 번 적용한다.
+ * 오프라인 캐시 설정은 이 모듈이 인스턴스를 만들 때 한 번 적용한다. 다른 Firestore 사용처가
+ * 모두 이 인스턴스를 주입받으므로 설정보다 먼저 쓰이는 경로가 없다.
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -24,7 +27,16 @@ object FirebaseModule {
 
     @Provides
     @Singleton
-    fun provideFirebaseFirestore(): FirebaseFirestore = FirebaseFirestore.getInstance()
+    fun provideFirebaseFirestore(): FirebaseFirestore =
+        FirebaseFirestore.getInstance().apply {
+            // 디스크 캐시가 기본값이지만 명시해 둔다. 옛 setPersistenceEnabled 는 deprecated 다.
+            // https://firebase.google.com/docs/firestore/manage-data/enable-offline
+            firestoreSettings =
+                FirebaseFirestoreSettings
+                    .Builder()
+                    .setLocalCacheSettings(PersistentCacheSettings.newBuilder().build())
+                    .build()
+        }
 
     @Provides
     @Singleton


### PR DESCRIPTION
## 📌 Issues

Closes #71

## 📎 Work Description

Firestore 오프라인 캐시 설정을 `SlowClockApplication` 에서 `FirebaseModule` 로 옮기고 deprecated API 를 걷어냈다.

- `FirebaseFirestoreSettings.Builder().setPersistenceEnabled(true)` 는 deprecated 다. `setLocalCacheSettings(PersistentCacheSettings.newBuilder().build())` 로 바꿨다. 디스크 캐시가 기본 동작이라 결과는 같다. 근거: [오프라인 데이터 사용 설정](https://firebase.google.com/docs/firestore/manage-data/enable-offline)
- 설정을 인스턴스를 제공하는 곳에 두었다. Firestore 를 쓰는 코드는 모두 `FirebaseModule` 이 주는 싱글턴을 주입받으므로(#57) 설정보다 먼저 쓰이는 경로가 없다. Application 이 `getInstance()` 를 한 번 더 부르던 것도 사라졌다.
- `FirebaseApp.initializeApp(this)` 를 지웠다. google-services 플러그인이 매니페스트에 넣는 `FirebaseInitProvider` 가 앱 시작 시 이미 초기화한다. `SlowClockApplication` 은 `@HiltAndroidApp` 선언만 남았다.

로컬 검증: `ktlintCheck`, `:app:assembleDebug`, `testDebugUnitTest`, `:app:lintDebug` 통과. `:app:compileDebugKotlin` 의 setPersistenceEnabled deprecation 경고가 사라졌다.

## 📷 Screenshot

동작 변경 없음.

## 💬 To Reviewers

- 남은 deprecation 경고(`toObject`, Material3 `Divider`)는 이 PR 범위 밖이다. 앞의 것은 #37 이 Firebase BOM 34 로 올리며 해소한다.
