### PR TITLE
fix: App Distribution 릴리스 노트를 워크플로가 만든 파일로 내보낸다

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,8 +81,9 @@ android {
             )
             signingConfig = signingConfigs.getByName("release")
             firebaseAppDistribution {
+                // 릴리스 노트는 배포 워크플로가 머지된 PR 본문에서 만들어 --releaseNotesFile 로 넘긴다.
+                // 여기서 releaseNotes 를 지정하면 그 파일을 덮어써 모든 배포가 같은 문구로 나간다(#79).
                 groups = "slowclock"
-                releaseNotes = "Release build for internal distribution"
             }
         }
     }


### PR DESCRIPTION
## 📌 Issues

Closes #79

## 📎 Work Description

App Distribution 배포 메일과 테스터 페이지의 릴리스 노트가 항상 「Release build for internal distribution」 한 줄로 나가던 문제를 고쳤다.

배포 워크플로는 머지된 PR 본문의 「📌 Issues」·「📎 Work Description」 을 뽑아 릴리스 노트 파일을 만들고 `--releaseNotesFile` 로 넘긴다. 그런데 `app/build.gradle.kts` 의 release 빌드 타입에 있던 `firebaseAppDistribution { releaseNotes = … }` 정적 문자열이 그 파일을 덮어썼다. 2026-09-05 배포본 `1u11is19i8en8` 을 App Distribution API 로 조회해 확인했다. DSL 에서 그 항목을 지우고 `groups` 만 남겼다.

로컬 검증: `ktlintCheck`, `:app:assembleRelease`, `node --test .github/scripts/*.test.mjs` 통과.

## 📷 Screenshot

다음 main 머지부터 테스터 메일에 그 PR 의 이슈 번호와 변경 내용이 실린다.

## 💬 To Reviewers

- 노트 생성 스크립트는 이슈 번호와 변경 내용이 모두 비면 업로드 전에 실패한다. 빈 노트로 배포가 나갈 일은 없다.
