### PR TITLE
refactor: Navigation Compose 를 Navigation 3 로 옮긴다

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.slowclock.android.application)
     alias(libs.plugins.slowclock.android.hilt)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.compose.screenshot)
     alias(libs.plugins.firebase.app.distribution)
     alias(libs.plugins.google.services)
@@ -105,7 +106,11 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
-    implementation(libs.androidx.navigation.compose)
+    // Navigation 3: 백스택은 앱이 소유하고 화면은 네비게이션 콜백만 받는다
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+    implementation(libs.kotlinx.serialization.core)
 
     // Firebase 초기화(Application)·Analytics·Firebase UI 로그인(AuthManager)
     implementation(platform(libs.firebase.bom))

--- a/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
@@ -1,15 +1,20 @@
-// app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
 package com.example.slowclock.navigation
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
 import com.example.slowclock.ui.addschedule.AddScheduleScreen
 import com.example.slowclock.ui.common.components.BottomNavigationBar
 import com.example.slowclock.ui.done.DoneScreen
@@ -19,105 +24,129 @@ import com.example.slowclock.ui.recommendation.RecommendationScreen
 import com.example.slowclock.ui.settings.SettingsScreen
 import com.example.slowclock.ui.settings.SettingsScreenShareCode
 import com.example.slowclock.ui.timeline.TimelineScreen
+import kotlinx.serialization.Serializable
+
+/**
+ * 화면 키. Navigation 3 에서는 백스택을 앱이 소유하고, 화면(feature 모듈)은 네비게이션 콜백만 받는다.
+ * 키는 백스택 저장·복원을 위해 직렬화 가능해야 한다.
+ */
+sealed interface SlowClockKey : NavKey
+
+@Serializable
+data object MainKey : SlowClockKey
+
+@Serializable
+data object DoneKey : SlowClockKey
+
+@Serializable
+data object TimelineKey : SlowClockKey
+
+@Serializable
+data object SettingsKey : SlowClockKey
+
+@Serializable
+data object ProfileKey : SlowClockKey
+
+@Serializable
+data object AddScheduleKey : SlowClockKey
+
+@Serializable
+data class EditScheduleKey(
+    val scheduleId: String,
+) : SlowClockKey
+
+@Serializable
+data object RecommendationKey : SlowClockKey
+
+@Serializable
+data object ShareCodeKey : SlowClockKey
+
+/** 하단 탭. 탭 키는 백스택의 루트(메인) 바로 위에 하나만 둔다. */
+private val tabKeys: Map<String, SlowClockKey> =
+    mapOf(
+        "main" to MainKey,
+        "done" to DoneKey,
+        "timeline" to TimelineKey,
+        "settings" to SettingsKey,
+    )
+
+private fun NavKey.tabRoute(): String? = tabKeys.entries.firstOrNull { it.value == this }?.key
+
+private fun NavBackStack<NavKey>.popBack() {
+    if (size > 1) removeLastOrNull()
+}
+
+private fun NavBackStack<NavKey>.showTab(key: SlowClockKey) {
+    while (size > 1) removeLastOrNull()
+    if (key != MainKey) add(key)
+}
 
 @Composable
 fun AppNavigation(modifier: Modifier = Modifier) {
-    val navController = rememberNavController()
-    val currentRoute by navController.currentBackStackEntryFlow.collectAsState(
-        initial = navController.currentBackStackEntry,
-    )
+    val backStack = rememberNavBackStack(MainKey)
+    // 추천 화면이 고른 제목. 일정 추가 entry 를 바꾸지 않고 전달하므로 그 화면의 ViewModel 이 유지된다.
+    var recommendedTitle by rememberSaveable { mutableStateOf<String?>(null) }
+    val currentRoute = backStack.lastOrNull()?.tabRoute() ?: ""
 
     Scaffold(
         modifier = modifier,
         bottomBar = {
             BottomNavigationBar(
-                currentRoute = currentRoute?.destination?.route ?: "main",
-                onNavigate = { navController.navigate(it) },
+                currentRoute = currentRoute,
+                onNavigate = { route -> tabKeys[route]?.let(backStack::showTab) },
             )
         },
     ) { innerPadding ->
-
-        NavHost(
-            navController = navController,
-            startDestination = "main",
+        NavDisplay(
+            backStack = backStack,
             modifier = Modifier.padding(innerPadding),
-        ) {
-            composable("main") {
-                MainScreen(
-                    onAddSchedule = {
-                        navController.navigate("add_schedule")
-                    },
-                    onEditSchedule = { scheduleId ->
-                        navController.navigate("edit_schedule/$scheduleId")
-                    },
-                    onNavigateToProfile = {
-                        navController.navigate("profile")
-                    },
-                    onNavigateToSettings = {
-                        navController.navigate("settings_share_code")
-                    },
-                )
-            }
-
-            composable("done") { DoneScreen() }
-            composable("timeline") { TimelineScreen() }
-            composable("settings") { SettingsScreen() }
-
-            composable(
-                route = "add_schedule",
-            ) {
-                val initialTitle =
-                    navController.currentBackStackEntry
-                        ?.savedStateHandle
-                        ?.get<String>("initial_title")
-
-                AddScheduleScreen(
-                    initialTitle = initialTitle,
-                    onNavigateBack = { navController.popBackStack() },
-                    onNavigateToRecommendation = {
-                        navController.navigate("recommendation")
-                    },
-                )
-            }
-
-            composable("edit_schedule/{scheduleId}") { backStackEntry ->
-                val scheduleId = backStackEntry.arguments?.getString("scheduleId") ?: ""
-                AddScheduleScreen(
-                    scheduleId = scheduleId,
-                    onNavigateBack = {
-                        navController.navigate("main") {
-                            popUpTo("main") { inclusive = false }
-                            launchSingleTop = true
-                        }
-                    },
-                    onNavigateToRecommendation = {
-                        navController.navigate("recommendation")
-                    },
-                )
-            }
-
-            composable("profile") {
-                ProfileScreen(
-                    onNavigateBack = { navController.popBackStack() },
-                )
-            }
-
-            composable("recommendation") {
-                RecommendationScreen(
-                    onSelectRecommendation = { title ->
-                        navController.previousBackStackEntry
-                            ?.savedStateHandle
-                            ?.set("initial_title", title)
-                        navController.popBackStack()
-                    },
-                )
-            }
-
-            composable("settings_share_code") {
-                SettingsScreenShareCode(
-                    onReturn = { navController.popBackStack() },
-                )
-            }
-        }
+            onBack = { backStack.popBack() },
+            entryDecorators =
+                listOf(
+                    rememberSaveableStateHolderNavEntryDecorator(),
+                    rememberViewModelStoreNavEntryDecorator(),
+                ),
+            entryProvider =
+                entryProvider {
+                    entry<MainKey> {
+                        MainScreen(
+                            onAddSchedule = { backStack.add(AddScheduleKey) },
+                            onEditSchedule = { scheduleId -> backStack.add(EditScheduleKey(scheduleId)) },
+                            onNavigateToProfile = { backStack.add(ProfileKey) },
+                            onNavigateToSettings = { backStack.add(ShareCodeKey) },
+                        )
+                    }
+                    entry<DoneKey> { DoneScreen() }
+                    entry<TimelineKey> { TimelineScreen() }
+                    entry<SettingsKey> { SettingsScreen() }
+                    entry<AddScheduleKey> {
+                        AddScheduleScreen(
+                            initialTitle = recommendedTitle,
+                            onNavigateBack = {
+                                recommendedTitle = null
+                                backStack.popBack()
+                            },
+                            onNavigateToRecommendation = { backStack.add(RecommendationKey) },
+                        )
+                    }
+                    entry<EditScheduleKey> { key ->
+                        AddScheduleScreen(
+                            scheduleId = key.scheduleId,
+                            onNavigateBack = { backStack.popBack() },
+                            onNavigateToRecommendation = { backStack.add(RecommendationKey) },
+                        )
+                    }
+                    entry<RecommendationKey> {
+                        RecommendationScreen(
+                            onSelectRecommendation = { title ->
+                                recommendedTitle = title
+                                backStack.popBack()
+                            },
+                        )
+                    }
+                    entry<ProfileKey> { ProfileScreen(onNavigateBack = { backStack.popBack() }) }
+                    entry<ShareCodeKey> { SettingsScreenShareCode(onReturn = { backStack.popBack() }) }
+                },
+        )
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -18,7 +18,7 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
             dependencies {
                 add("implementation", project(":core:ui"))
                 add("implementation", project(":core:data"))
-                add("implementation", libs.library("androidx-hilt-navigation-compose"))
+                add("implementation", libs.library("androidx-hilt-lifecycle-viewmodel-compose"))
                 add("implementation", libs.library("androidx-lifecycle-viewmodel-compose"))
                 add("implementation", libs.library("androidx-lifecycle-runtime-compose"))
 

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.ui.addschedule.components.RecommendationPlaceholder
 import com.example.slowclock.ui.addschedule.components.RecurringSection

--- a/feature/main/src/main/java/com/example/slowclock/ui/done/DoneScreen.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/done/DoneScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.data.model.Schedule
 import com.example.slowclock.ui.common.components.ErrorCard

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.ui.common.components.ErrorCard
 import com.example.slowclock.ui.common.dialog.DeleteConfirmDialog

--- a/feature/main/src/main/java/com/example/slowclock/ui/settings/SettingsScreenShareCode.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/settings/SettingsScreenShareCode.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.ui.mvi.ObserveSignal
 

--- a/feature/main/src/main/java/com/example/slowclock/ui/timeline/TimelineScreen.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/timeline/TimelineScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.ui.common.components.ErrorCard
 import java.text.SimpleDateFormat

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.ui.mvi.ObserveSignal
 import kotlinx.coroutines.launch

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,8 @@ activityCompose = "1.13.0"
 firebaseBom = "34.18.0"
 lifecycleViewmodelCompose = "2.11.0"
 materialIconsExtended = "1.7.8"
-navigationCompose = "2.10.0"
+navigation3 = "1.1.7"
+lifecycleViewmodelNavigation3 = "2.11.0"
 firebaseUiAuth = "9.1.1"
 volley = "1.2.1"
 # --- 운영 툴링 도입 (Afternote 패리티): ktlint / compose screenshot test / firebase app distribution ---
@@ -26,7 +27,7 @@ googleServices = "4.5.0"
 hilt = "2.60.1"
 # KSP 2.3.x 는 Kotlin 버전과 독립이다(KSP 2.3.0 릴리스 노트). 2.3.10 부터 AGP 9 내장 Kotlin 의 R 클래스 해석을 고쳤다.
 ksp = "2.3.11"
-hiltNavigationCompose = "1.4.0"
+hiltLifecycleViewmodelCompose = "1.4.0"
 kotlinxSerialization = "1.11.0"
 # --- 단위 테스트 ---
 mockk = "1.14.11"
@@ -58,7 +59,9 @@ firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
-androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
+androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
+androidx-lifecycle-viewmodel-navigation3 = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNavigation3" }
 firebase-ui-auth = { group = "com.firebaseui", name = "firebase-ui-auth", version.ref = "firebaseUiAuth" }
 volley = { group = "com.android.volley", name = "volley", version.ref = "volley" }
 # 운영 툴링
@@ -67,7 +70,7 @@ screenshot-validation-api = { group = "com.android.tools.screenshot", name = "sc
 # 멀티모듈 DI (Hilt)
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
-androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+androidx-hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltLifecycleViewmodelCompose" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 # build-logic 컨벤션 플러그인이 classpath 로 쓰는 gradle 플러그인 좌표
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -80,6 +83,7 @@ hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-p
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }
 compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot" }
 firebase-app-distribution = { id = "com.google.firebase.appdistribution", version.ref = "firebaseAppDistribution" }


### PR DESCRIPTION
## 📌 Issues

Closes #62
Refs #53

## 📎 Work Description

화면 이동을 Navigation Compose 에서 [Navigation 3](https://developer.android.com/guide/navigation/navigation-3/basics) 로 옮겼다. 백스택을 앱이 소유하고 화면은 콜백만 받는 구조라, 문자열 라우트와 `savedStateHandle` 을 통한 인자 전달이 사라진다.

- `AppNavigation` 이 `rememberNavBackStack(MainKey)` 로 백스택을 들고 `NavDisplay` 로 그린다. 화면 키는 `SlowClockKey` sealed interface 를 구현한 `@Serializable` 타입이라 프로세스 종료 뒤에도 복원된다. `"edit_schedule/{scheduleId}"` 같은 문자열 조립과 파싱이 `EditScheduleKey(scheduleId)` 하나로 바뀌었다.
- 엔트리 데코레이터는 `rememberSaveableStateHolderNavEntryDecorator()` 와 `rememberViewModelStoreNavEntryDecorator()` 를 준다. 후자가 엔트리마다 `ViewModelStore` 를 만들어 화면 ViewModel 의 수명을 백스택에 맞춘다.
- 추천 화면이 고른 제목은 `rememberSaveable` 상태로 들고 일정 추가 엔트리에 파라미터로 넘긴다. 종전에는 이전 엔트리의 `savedStateHandle` 에 써 넣었다. 엔트리를 갈아 끼우지 않으므로 입력 중이던 일정 추가 화면의 ViewModel 이 유지된다.
- 탭 이동은 백스택을 루트까지 비운 뒤 탭 키를 올린다. 탭 사이를 오갈 때 상세 화면이 쌓이지 않는다.
- Hilt 주입은 `androidx.hilt:hilt-navigation-compose` 대신 `androidx.hilt:hilt-lifecycle-viewmodel-compose` 를 쓴다. 전자는 `navigation-compose` 를 전이 의존으로 다시 끌어오고, 후자의 `hiltViewModel()` 은 `NavEntry` 가 제공하는 `ViewModelStoreOwner` 에서도 동작한다. 화면 6곳의 import 만 바뀌었다.
- 의존: `androidx.navigation3:navigation3-runtime`·`navigation3-ui` 1.1.7, `androidx.lifecycle:lifecycle-viewmodel-navigation3` 2.11.0, kotlinx-serialization 플러그인. `navigation-compose` 는 카탈로그에서 지웠다.

로컬 검증: `ktlintCheck`, `:app:assembleDebug`, `testDebugUnitTest`, `lintDebug`(전 모듈), `:app:bundleRelease` 통과. 에뮬레이터(Pixel 7, API 36)에 debug 빌드를 올려 탭 네 개 이동, 일정 추가 화면 진입, 뒤로가기 복귀를 확인했다. 로그에 예외가 없고 화면마다 ViewModel 이 주입된다.

## 📷 Screenshot

화면 자체는 그대로다. 이동 경로만 바뀌었다.

## 💬 To Reviewers

- 예측형 뒤로가기(predictive back)는 `NavDisplay` 가 처리한다. 알람 전체화면 Activity 의 뒤로가기 무력화 문제는 별개이며 #65 에서 다룬다.
