### PR TITLE
chore: deprecated API 사용을 정리한다

### DIFF
--- a/core/alarm/src/main/java/com/example/slowclock/core/alarm/ScheduleAlarmHelper.kt
+++ b/core/alarm/src/main/java/com/example/slowclock/core/alarm/ScheduleAlarmHelper.kt
@@ -54,7 +54,7 @@ object ScheduleAlarmHelper {
         alarmManager: AlarmManager,
         isFullScreen: Boolean,
     ) {
-        schedule.startTime?.toDate()?.time?.takeIf { it > now }?.let { triggerTime ->
+        schedule.startTime.toDate().time.takeIf { it > now }?.let { triggerTime ->
             val intent = createAlarmIntent(context, schedule, "시작", isFullScreen)
             val requestCode = generateStartRequestCode(schedule.id)
             val pendingIntent = createPendingIntent(context, intent, requestCode)
@@ -107,7 +107,7 @@ object ScheduleAlarmHelper {
     ): Intent =
         Intent(context, AlarmReceiver::class.java).apply {
             putExtra("title", "${schedule.title} ($type)")
-            putExtra("desc", schedule.description ?: "")
+            putExtra("desc", schedule.description)
             putExtra("isFullScreen", isFullScreen)
             putExtra("scheduleId", schedule.id)
             putExtra("alarmType", type)
@@ -181,7 +181,7 @@ object ScheduleAlarmHelper {
             val intent =
                 Intent(context, AlarmReceiver::class.java).apply {
                     putExtra("title", "${schedule.title} ($type)")
-                    putExtra("desc", schedule.description ?: "")
+                    putExtra("desc", schedule.description)
                     putExtra("scheduleId", schedule.id)
                     putExtra("alarmType", type)
                 }

--- a/core/alarm/src/main/java/com/example/slowclock/ui/alarm/AlarmFullScreenActivity.kt
+++ b/core/alarm/src/main/java/com/example/slowclock/ui/alarm/AlarmFullScreenActivity.kt
@@ -30,18 +30,10 @@ class AlarmFullScreenActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // 잠금 화면 위에 표시 + 화면 켜기
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O_MR1) {
-            setShowWhenLocked(true)
-            setTurnScreenOn(true)
-        } else {
-            window.addFlags(
-                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
-                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON or
-                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON or
-                    WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD,
-            )
-        }
+        // 잠금 화면 위에 표시하고 화면을 켠다. minSdk 32 라 API 27 의 창 플래그 경로는 필요 없다.
+        setShowWhenLocked(true)
+        setTurnScreenOn(true)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         setContentView(R.layout.activity_alarm_fullscreen)
 

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
@@ -106,7 +106,7 @@ internal fun AddScheduleContent(
                     }
                 },
                 colors =
-                    TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.surface,
                     ),
             )

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/components/RecurringSection.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/components/RecurringSection.kt
@@ -11,10 +11,10 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -92,7 +92,7 @@ fun RecurringSection(
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                         modifier =
                             Modifier
-                                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                                 .fillMaxWidth(),
                         textStyle = MaterialTheme.typography.bodyLarge,
                     )

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainScreen.kt
@@ -145,7 +145,7 @@ internal fun MainContent(
                     }
                 },
                 colors =
-                    TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.surface,
                     ),
             )

--- a/feature/main/src/main/java/com/example/slowclock/ui/timeline/Timeline.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/timeline/Timeline.kt
@@ -20,9 +20,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -55,11 +55,11 @@ fun Timeline(
                 .padding(horizontal = 24.dp),
     ) {
         // 전체 세로선: Box 전체 높이를 따라 고정
-        Divider(
+        VerticalDivider(
             color = MaterialTheme.colorScheme.secondary,
+            thickness = 2.dp,
             modifier =
                 Modifier
-                    .width(2.dp)
                     .fillMaxHeight()
                     .align(Alignment.Center),
         )

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
@@ -104,7 +104,7 @@ internal fun ProfileContent(
                     }
                 },
                 colors =
-                    TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.surface,
                     ),
             )


### PR DESCRIPTION
## 📌 Issues

Closes #78

## 📎 Work Description

컴파일 경고로 남던 deprecated API 사용과 죽은 분기를 정리했다.

- `Timeline` 의 세로 기준선이 Material3 `Divider` 를 쓰고 있었다. 이름이 바뀐 API 중 이 자리에 맞는 것은 `VerticalDivider` 다. `width(2.dp)` 대신 `thickness` 로 두께를 준다.
- `centerAlignedTopAppBarColors` 를 `topAppBarColors` 로 바꿨다(메인·일정 추가·프로필 세 화면).
- `MenuAnchorType` 을 `ExposedDropdownMenuAnchorType` 으로 바꿨다.
- `AlarmFullScreenActivity` 의 API 27 미만 창 플래그 분기를 지웠다. minSdk 가 32 라 실행되지 않는 경로이고, 그 분기 때문에 `FLAG_SHOW_WHEN_LOCKED` 계열 deprecation 경고가 셋 남아 있었다. 화면을 켜 두는 `FLAG_KEEP_SCREEN_ON` 만 남긴다.
- `ScheduleAlarmHelper` 에서 항상 왼쪽만 반환하던 엘비스 연산자 둘과 non-null 수신자에 대한 safe call 하나를 걷어냈다.

FCM 토큰 API(`getToken`·`onNewToken`) 의 deprecation 은 등록 단위를 설치 ID 로 바꾸는 작업이라 Cloud Functions 와 Firestore 문서까지 함께 옮겨야 한다. 그건 #84 로 분리했다.

로컬 검증: `ktlintCheck`, `:app:assembleDebug`, `testDebugUnitTest`, `lintDebug`(전 모듈) 통과.

## 📷 Screenshot

타임라인 세로선의 두께와 색은 그대로다.

## 💬 To Reviewers

- `hiltViewModel` deprecation 경고는 #62 가 `hilt-lifecycle-viewmodel-compose` 로 옮기며 사라진다.
