### PR TITLE
docs: Firestore 데이터 경계와 규칙 운용 방법을 남긴다

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,5 @@ GitHub Actions 파이프라인은 Afternote-FE 의 것을 1인 운영에 맞게 
 - Google Play 내부 테스트 트랙(수동 실행): [docs/play-release.md](docs/play-release.md)
 - screenshot baseline 은 CI 컨테이너에서 만든다(`screenshot-baseline` 라벨): [docs/testing/screenshot.md](docs/testing/screenshot.md)
 - 외부 설정(GitHub environment·secret, GCP WIF, Firebase 앱, Pages, 브랜치 보호): [docs/release/ci-setup.md](docs/release/ci-setup.md)
+- Firestore 데이터 경계와 보안 규칙 운용: [docs/firestore.md](docs/firestore.md)
 - 워크플로 정책은 `.github/scripts/*.test.mjs` 에 고정돼 있다. 워크플로를 고치면 `node --test .github/scripts/*.test.mjs` 와 `scripts/repository-quality.sh` 를 먼저 돌린다.

--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -1,0 +1,55 @@
+# Firestore 데이터 경계
+
+무엇을 어디에 담고 누가 읽을 수 있는지 정하는 문서다. 규칙 파일은 [`firestore.rules`](../firestore.rules) 이고, 그 규칙이 실제로 그렇게 동작하는지는 [`firestore-tests/rules.test.mjs`](../firestore-tests/rules.test.mjs) 가 에뮬레이터로 잠근다.
+
+## 컬렉션
+
+| 경로 | 담는 값 | 읽기 | 쓰기 |
+|---|---|---|---|
+| `users/{uid}` | 이름, 이메일, 공유 코드, FCM 토큰, 생성·수정 시각 | 본인만 | 본인만 |
+| `publicProfiles/{uid}` | id, 이름, 공유 코드 | 로그인한 사용자 전체 | 본인만, 이 세 필드만 |
+| `schedules/{id}` | 일정 제목·설명·시각·완료 여부·소유자 uid·공유 코드 | 소유자, 그리고 `sharedCode` 가 있으면 로그인 사용자 | 소유자. 공유 일정은 `completed`·`updatedAt` 만 |
+| `notifications/{id}` | 알림 기록(소유자 uid) | 소유자 | 소유자 |
+| `shareCodeWatchers/{code}/tokens/{uid}` | 그 공유 코드를 보는 기기의 FCM 토큰 | 본인 문서만 | 본인 문서만 |
+| `scheduleRecommendations/{id}` | 유형별 추천 일정 | 로그인한 사용자 전체 | 아무도 못 함(콘솔로만) |
+
+## 새 필드는 어디에 두는가
+
+기준은 하나다. 다른 사용자에게 보여야 하면 `publicProfiles`, 아니면 `users` 다.
+
+Firestore 에는 필드 단위 읽기 제한이 없다. 문서 하나를 읽게 허용하면 그 문서의 모든 필드가 함께 나간다. 그래서 이름 하나를 보여 주려고 `users` 를 열면 이메일과 FCM 토큰도 같이 열린다. 실제로 그런 규칙이 배포돼 있었고 #95 에서 이 구조로 바꿨다.
+
+`publicProfiles` 는 쓰기 규칙이 필드 목록을 `id`·`name`·`shareCode` 로 묶는다. 필드를 늘리려면 규칙과 테스트를 함께 고쳐야 한다. 그 마찰이 의도한 것이다.
+
+## 서버가 관리자 권한으로 읽는 곳
+
+Cloud Functions 는 Admin SDK 로 동작해 규칙을 거치지 않는다. 규칙만 읽으면 이 경로를 놓친다.
+
+- `sendFcmToShareCodeWatchers`(`functions/index.js`): `schedules` 문서가 바뀌면 `shareCodeWatchers/{code}/tokens` 를 읽어 감시자에게 알림을 보낸다. 클라이언트는 남의 토큰을 읽지 않는다.
+
+## 규칙 테스트
+
+```bash
+cd firestore-tests
+npm ci
+npm test
+```
+
+`firebase emulators:exec` 가 Firestore 에뮬레이터에 `firestore.rules` 를 올리고 테스트를 돌린다. JDK 가 필요하다. CI 에서는 [`firestore-rules.yml`](../.github/workflows/firestore-rules.yml) 이 규칙·테스트가 바뀐 PR 과 main push 에서 같은 명령을 돌린다.
+
+테스트는 두 가지를 잠근다. 앱이 실제로 하는 접근이 통과하는지와 남의 데이터 접근이 막히는지다. 규칙을 좁힐 때 기능이 깨지는 것을 여기서 먼저 잡는다.
+
+## 배포
+
+```bash
+firebase deploy --only firestore:rules
+firebase deploy --only firestore:indexes
+```
+
+규칙은 배포해야 적용된다. 저장소 파일을 고치는 것만으로는 운영 데이터베이스가 바뀌지 않는다. 인덱스는 [`firestore.indexes.json`](../firestore.indexes.json) 이고 지금은 `schedules`(userId + startTime) 하나다.
+
+배포 전에 `npm test` 로 규칙 테스트를 돌린다. 규칙을 좁히는 배포는 앱의 읽기 경로를 끊을 수 있어, 배포 뒤 기기에서 로그인·일정 조회·공유 코드 입력까지 확인한다.
+
+## Play 데이터 보안 선언과의 관계
+
+[`play-release.md`](play-release.md) 의 데이터 보안 표가 수집·공유 항목의 정본이다. 컬렉션을 늘리거나 담는 값을 바꾸면 그 표와 [`privacy.html`](privacy.html) 을 함께 고친다. 규칙이 선언보다 넓으면 선언이 거짓이 된다.

--- a/docs/play-release.md
+++ b/docs/play-release.md
@@ -48,7 +48,7 @@ Firebase App Distribution 과 Google Play 의 목적을 분리하고, 첫 Play �
 | 금융 기능 | 없음 | |
 | 건강 | 해당 없음. 의료 기기·건강 데이터·건강 기록 기능이 없고, 건강 관련 콘텐츠도 앱 안에 없다 | 외부 사이트로 나가는 링크뿐(#51 에서 스크래핑 제거) |
 | 데이터 보안: 수집 | 개인 정보(이름, 이메일 주소, 사용자 ID), 앱 활동(앱 상호작용, 기타 사용자 생성 콘텐츠: 일정·메모·그룹 이름), 기기 또는 기타 ID(FCM 토큰, Firebase 설치 ID) | Firebase Auth·Firestore·FCM·Analytics |
-| 데이터 보안: 공유 | 제3자 공유 없음. Firebase 는 서비스 제공업체. 가족 그룹 공유는 사용자가 시작한 행동 | privacy.html 4절 |
+| 데이터 보안: 공유 | 제3자 공유 없음. Firebase 는 서비스 제공업체. 가족 그룹 공유는 사용자가 시작한 행동 | privacy.html 4절, [firestore.md](firestore.md) 의 컬렉션 표 |
 | 데이터 보안: 처리 | 전송 중 암호화 「예」. 계정 삭제 요청 방법 「예」: 앱 안 내 정보 화면과 `https://1hyok.me/SlowClock/delete-account.html`(#46) | HTTPS, #46 |
 | 데이터 보안: 목적 | 개인 정보·앱 활동·기기 ID 모두 「앱 기능」. 앱 상호작용은 「분석」 추가 | Analytics 는 광고 ID 없이 사용 |
 | 광고 ID | 아니오 | manifest `tools:node="remove"` |


### PR DESCRIPTION
## 📌 Issues

Closes #99
Refs #92, #95

## 📎 Work Description

Firestore 데이터 경계를 `docs/firestore.md` 로 남겼다. #92 에서 규칙을 저장소로 가져오고 #95 에서 공개 프로필을 분리했지만, 어떤 컬렉션에 무엇이 들어가고 누가 읽는지는 규칙 파일을 읽어야만 알 수 있었다.

- 컬렉션 여섯 개의 담는 값과 읽기·쓰기 주체를 표로 적었다.
- 새 필드를 어디에 둘지 정하는 기준을 적었다. 다른 사용자에게 보여야 하면 `publicProfiles`, 아니면 `users` 다. Firestore 에 필드 단위 읽기 제한이 없어서 문서 하나를 열면 모든 필드가 함께 나가는 것이 이유다.
- Cloud Functions 가 관리자 권한으로 읽는 `shareCodeWatchers` 경로를 적었다. 규칙을 거치지 않아 규칙 파일만 읽으면 놓친다.
- 규칙 테스트 실행법과 배포 명령, 배포 뒤 기기에서 확인할 것을 적었다.
- `docs/play-release.md` 의 데이터 보안 표와 서로 링크했다. 한쪽만 바뀌면 선언이 거짓이 된다.

로컬 검증: `node .github/scripts/verify-markdown-links.mjs` 통과(12개 파일).

## 📷 Screenshot

문서라 화면 없음.

## 💬 To Reviewers

- 규칙 배포는 아직 하지 않았다. #95 의 규칙이 적용돼야 앱이 공개 프로필을 쓸 수 있다.
