### PR TITLE
fix: 로그인을 취소해도 앱을 쓰고 다시 로그인할 수 있게 한다 (103)

### DIFF
--- a/app/src/main/java/com/example/slowclock/MainActivity.kt
+++ b/app/src/main/java/com/example/slowclock/MainActivity.kt
@@ -104,7 +104,7 @@ class MainActivity : ComponentActivity() {
                             ThemeMode.DARK -> true
                         },
                 ) {
-                    AppNavigation()
+                    AppNavigation(onSignIn = { authManager.signInWithGoogle() })
                 }
             }
             Log.d("MAIN", "onCreate 완료")

--- a/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
@@ -82,7 +82,10 @@ private fun NavBackStack<NavKey>.showTab(key: SlowClockKey) {
 }
 
 @Composable
-fun AppNavigation(modifier: Modifier = Modifier) {
+fun AppNavigation(
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val backStack = rememberNavBackStack(MainKey)
     // 추천 화면이 고른 제목. 일정 추가 entry 를 바꾸지 않고 전달하므로 그 화면의 ViewModel 이 유지된다.
     var recommendedTitle by rememberSaveable { mutableStateOf<String?>(null) }
@@ -118,6 +121,7 @@ fun AppNavigation(modifier: Modifier = Modifier) {
                             onEditSchedule = { scheduleId -> backStack.add(EditScheduleKey(scheduleId)) },
                             onNavigateToProfile = { backStack.add(ProfileKey) },
                             onNavigateToSettings = { backStack.add(ShareCodeKey) },
+                            onSignIn = onSignIn,
                         )
                     }
                     entry<DoneKey> { DoneScreen() }
@@ -148,7 +152,9 @@ fun AppNavigation(modifier: Modifier = Modifier) {
                             },
                         )
                     }
-                    entry<ProfileKey> { ProfileScreen(onNavigateBack = { backStack.popBack() }) }
+                    entry<ProfileKey> {
+                        ProfileScreen(onNavigateBack = { backStack.popBack() }, onSignIn = onSignIn)
+                    }
                     entry<ShareCodeKey> { SettingsScreenShareCode(onReturn = { backStack.popBack() }) }
                 },
         )

--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/AuthRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/AuthRepository.kt
@@ -2,6 +2,9 @@ package com.example.slowclock.data.remote.repository
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthRecentLoginRequiredException
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -35,6 +38,21 @@ class AuthRepository
 
         val currentUid: String?
             get() = auth.currentUser?.uid
+
+        /**
+         * 로그인한 계정의 uid. 로그인하지 않았으면 null 이다. 현재 값을 먼저 내고 바뀔 때마다 낸다.
+         *
+         * 화면이 초기화 시점의 uid 를 들고 있으면 로그인에 성공해도 그대로 남는다. 그래서 흐름으로 낸다.
+         */
+        fun observeCurrentUid(): Flow<String?> =
+            callbackFlow {
+                val listener =
+                    FirebaseAuth.AuthStateListener { firebaseAuth ->
+                        trySend(firebaseAuth.currentUser?.uid)
+                    }
+                auth.addAuthStateListener(listener)
+                awaitClose { auth.removeAuthStateListener(listener) }
+            }
 
         val currentProfile: Profile?
             get() =

--- a/core/ui/src/main/java/com/example/slowclock/ui/common/components/SignInPrompt.kt
+++ b/core/ui/src/main/java/com/example/slowclock/ui/common/components/SignInPrompt.kt
@@ -1,0 +1,78 @@
+package com.example.slowclock.ui.common.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * 로그인하지 않았을 때의 안내와 버튼. 로그인 창을 여는 것은 Activity 몫이라 [onSignIn] 으로 받는다.
+ *
+ * 로그인 창을 취소한 사용자가 되돌아올 길이다. 종전에는 빈 화면만 남고 다시 로그인할 방법이 없었다(#103).
+ */
+@Composable
+fun SignInPrompt(
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.AccountCircle,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(56.dp),
+            )
+            Text(
+                text = "로그인하면 일정을 쓸 수 있습니다",
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = "일정은 계정에 저장되어 기기를 바꿔도 남습니다. 가족과 나눠 보려면 계정이 필요합니다",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Button(
+                onClick = onSignIn,
+                shape = RoundedCornerShape(16.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(64.dp),
+            ) {
+                Text(text = "Google 계정으로 로그인", style = MaterialTheme.typography.titleLarge)
+            }
+        }
+    }
+}

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainContract.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainContract.kt
@@ -58,6 +58,8 @@ data class MainUiState(
     /** null 이 아니면 삭제 확인 다이얼로그가 떠 있다. */
     val scheduleToDelete: Schedule? = null,
     val currentUserId: String = "",
+    /** 로그인 여부를 아직 모르는 동안에는 로그인 안내를 띄우지 않는다. */
+    val isSignedInKnown: Boolean = false,
     /** true 면 정확한 알람 권한을 설명하는 다이얼로그가 떠 있다. */
     val showExactAlarmNotice: Boolean = false,
     /** null 이 아니면 화면이 시스템 설정을 한 번 연다. */

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.slowclock.ui.common.components.ErrorCard
+import com.example.slowclock.ui.common.components.SignInPrompt
 import com.example.slowclock.ui.common.dialog.DeleteConfirmDialog
 import com.example.slowclock.ui.main.components.CurrentTaskSection
 import com.example.slowclock.ui.main.components.EmptyStateCard
@@ -55,6 +56,7 @@ fun MainScreen(
     onEditSchedule: (String) -> Unit,
     onNavigateToProfile: () -> Unit,
     onNavigateToSettings: () -> Unit,
+    onSignIn: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MainViewModel = hiltViewModel(),
 ) {
@@ -74,6 +76,7 @@ fun MainScreen(
         onEditSchedule = onEditSchedule,
         onNavigateToProfile = onNavigateToProfile,
         onNavigateToSettings = onNavigateToSettings,
+        onSignIn = onSignIn,
         modifier = modifier,
     )
 }
@@ -88,8 +91,10 @@ internal fun MainContent(
     onEditSchedule: (String) -> Unit,
     onNavigateToProfile: () -> Unit,
     onNavigateToSettings: () -> Unit,
+    onSignIn: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val isSignedOut = state.isSignedInKnown && state.currentUserId.isBlank()
     val dateFormat = remember { SimpleDateFormat("yyyy년 M월 d일 EEEE", Locale.KOREAN) }
     val locale = LocalLocale.current.platformLocale
     val timeFormat = remember(locale) { SimpleDateFormat("HH:mm", locale) }
@@ -167,6 +172,7 @@ internal fun MainContent(
             )
         },
         floatingActionButton = {
+            if (isSignedOut) return@Scaffold
             FloatingActionButton(
                 onClick = onAddSchedule,
                 containerColor = MaterialTheme.colorScheme.primary,
@@ -200,6 +206,11 @@ internal fun MainContent(
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth(),
                 )
+            }
+
+            if (isSignedOut) {
+                item { SignInPrompt(onSignIn = onSignIn) }
+                return@LazyColumn
             }
 
             state.currentSchedule?.let { schedule ->

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/MainViewModel.kt
@@ -40,13 +40,13 @@ class MainViewModel
         private var scheduleJob: Job? = null
 
         init {
-            dispatch(MainReducerEvent.UserResolved(authRepository.currentUid.orEmpty()))
+            observeSignedInUser()
             // 정확한 알람 권한이 없으면 첫 진입에 한 번만 이유를 설명한다. 설정으로 보내는 건
             // 사용자가 「설정 열기」 를 눌렀을 때다(#83).
             if (!alarmScheduler.canScheduleExactAlarms() && !settingsRepository.hasSeenExactAlarmNotice()) {
                 dispatch(MainReducerEvent.ExactAlarmNoticeShown)
             }
-            observeTodaySchedules()
+            // 일정 구독은 로그인 상태를 받은 뒤 observeSignedInUser 가 건다.
             observeSharedReminders()
         }
 
@@ -115,7 +115,7 @@ class MainViewModel
         ): MainUiState =
             when (event) {
                 is MainReducerEvent.UserResolved -> {
-                    state.copy(currentUserId = event.userId)
+                    state.copy(currentUserId = event.userId, isSignedInKnown = true)
                 }
 
                 MainReducerEvent.Loading -> {
@@ -211,6 +211,16 @@ class MainViewModel
                 completedCount = schedules.count { it.completed },
                 totalCount = schedules.size,
             )
+
+        /** 로그인·로그아웃이 화면에 바로 반영되도록 흐름으로 받는다. */
+        private fun observeSignedInUser() {
+            viewModelScope.launch {
+                authRepository.observeCurrentUid().collect { uid ->
+                    dispatch(MainReducerEvent.UserResolved(uid.orEmpty()))
+                    if (uid != null) observeTodaySchedules()
+                }
+            }
+        }
 
         private fun observeTodaySchedules() {
             scheduleJob?.cancel()

--- a/feature/main/src/test/java/com/example/slowclock/ui/main/MainViewModelTest.kt
+++ b/feature/main/src/test/java/com/example/slowclock/ui/main/MainViewModelTest.kt
@@ -51,6 +51,7 @@ class MainViewModelTest {
     fun setUp() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
         every { authRepository.currentUid } returns "uid-1"
+        every { authRepository.observeCurrentUid() } returns flowOf("uid-1")
         every { scheduleRepository.observeSchedulesForDate(any()) } returns todaySchedules
         every { settingsRepository.observeShareCode() } returns shareCode
         every { scheduleRepository.observeSchedulesBySharedCode(any()) } returns flowOf(emptyList())

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileContract.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileContract.kt
@@ -37,6 +37,8 @@ data class ProfileUiState(
     val email: String = "",
     val shareCode: String = "",
     val loadError: String? = null,
+    /** 로그인하지 않아 정보를 보여 줄 수 없다. */
+    val isSignedOut: Boolean = false,
     val isDeleteConfirmVisible: Boolean = false,
     val isDeleting: Boolean = false,
     val userMessage: String? = null,
@@ -45,6 +47,9 @@ data class ProfileUiState(
 
 /** 내 정보 화면의 상태가 겪은 것. 화면은 만들지 않고 ViewModel 만 dispatch 한다. */
 sealed interface ProfileReducerEvent : ReducerEvent {
+    /** 로그인하지 않았다. 오류가 아니라 로그인 안내를 띄우는 상태다. */
+    data object SignedOut : ProfileReducerEvent
+
     data class Loaded(
         val name: String,
         val email: String,

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.slowclock.ui.common.components.SignInPrompt
 import com.example.slowclock.ui.mvi.ObserveSignal
 import kotlinx.coroutines.launch
 
@@ -44,6 +45,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun ProfileScreen(
     onNavigateBack: () -> Unit,
+    onSignIn: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ProfileViewModel = hiltViewModel(),
 ) {
@@ -68,6 +70,7 @@ fun ProfileScreen(
         onIntent = viewModel::onIntent,
         snackbarHostState = snackbarHostState,
         onNavigateBack = onNavigateBack,
+        onSignIn = onSignIn,
         modifier = modifier,
     )
 }
@@ -80,6 +83,7 @@ internal fun ProfileContent(
     onIntent: (ProfileIntent) -> Unit,
     snackbarHostState: SnackbarHostState,
     onNavigateBack: () -> Unit,
+    onSignIn: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -122,7 +126,12 @@ internal fun ProfileContent(
         ) {
             when {
                 state.isLoading -> Text("로딩 중...")
+
+                // 로그인하지 않은 상태는 오류가 아니라 할 일이다. 버튼을 주어 되돌아갈 길을 만든다(#103).
+                state.isSignedOut -> SignInPrompt(onSignIn = onSignIn)
+
                 state.loadError != null -> Text(state.loadError, color = MaterialTheme.colorScheme.error)
+
                 else -> ProfileBody(state = state, onIntent = onIntent)
             }
         }

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileViewModel.kt
@@ -53,6 +53,10 @@ class ProfileViewModel
                     state.copy(isLoading = false, loadError = event.message)
                 }
 
+                ProfileReducerEvent.SignedOut -> {
+                    state.copy(isLoading = false, isSignedOut = true, loadError = null)
+                }
+
                 ProfileReducerEvent.DeleteConfirmShown -> {
                     state.copy(isDeleteConfirmVisible = true)
                 }
@@ -86,7 +90,7 @@ class ProfileViewModel
             viewModelScope.launch {
                 val authProfile = authRepository.currentProfile
                 if (authProfile == null) {
-                    dispatch(ProfileReducerEvent.LoadFailed("로그인이 필요합니다."))
+                    dispatch(ProfileReducerEvent.SignedOut)
                     return@launch
                 }
                 val user = userRepository.getCurrentUser()

--- a/feature/profile/src/test/java/com/example/slowclock/ui/profile/ProfileViewModelTest.kt
+++ b/feature/profile/src/test/java/com/example/slowclock/ui/profile/ProfileViewModelTest.kt
@@ -76,13 +76,14 @@ class ProfileViewModelTest {
         }
 
     @Test
-    fun `로그인돼 있지 않으면 안내 문구를 둔다`() =
+    fun `로그인돼 있지 않으면 로그인 안내 상태가 된다`() =
         runTest {
             every { authRepository.currentProfile } returns null
 
             val state = createViewModel().uiState.value
 
-            assertEquals("로그인이 필요합니다.", state.loadError)
+            assertTrue(state.isSignedOut)
+            assertNull(state.loadError)
         }
 
     @Test


### PR DESCRIPTION
## 📌 Issues

closes #103

## 📎 Work Description

로그인 창을 취소하면 빈 화면만 남고 다시 로그인할 길이 없었습니다. 메인 화면이 초기화 시점의 uid 를 한 번만 읽어서, 그 뒤에 로그인해도 화면은 그대로 비어 있었습니다.

- `AuthRepository.observeCurrentUid()` 를 두어 로그인 상태를 흐름으로 냅니다. 현재 값을 먼저 내고 바뀔 때마다 냅니다.
- 메인 화면이 이 흐름을 구독합니다. 로그인해야 일정 구독을 시작하고, 로그인 결과가 바로 화면에 반영됩니다.
- 로그인하지 않은 동안에는 일정 목록 대신 `SignInPrompt` 를 띄우고 일정 추가 버튼을 감춥니다. 저장할 수 없는 화면으로 들어가지 않게 합니다.
- 내 정보 화면도 같은 안내를 씁니다. 종전에는 "로그인이 필요합니다" 를 오류 문구 자리에 넣었는데, 로그인하지 않은 것은 오류가 아니라 할 일이라 상태로 옮겼습니다.

## 📷 Screenshot

에뮬레이터에서 찍었습니다. 이미지 첨부 경로가 이번에 막혀 글로 적습니다.

메인 화면은 날짜 아래에 카드가 하나 뜹니다. 사람 모양 아이콘, "로그인하면 일정을 쓸 수 있습니다", 설명 두 줄, 파란 "Google 계정으로 로그인" 버튼입니다. 오른쪽 아래 일정 추가 버튼은 없습니다. 내 정보 화면도 같은 카드를 씁니다.

## 💬 To Reviewers

에뮬레이터에서 앱 데이터를 지우고 확인했습니다. 로그인 창을 취소하면 안내가 뜨고, 안내의 버튼을 누르면 Google 로그인 창이 다시 열립니다.

앱을 새로 켤 때 로그인 창이 먼저 뜨는 동작은 그대로 두었습니다. 이번 범위는 취소한 뒤에 되돌아올 길을 만드는 것입니다.
