### PR TITLE
fix: 글자 크기를 키워도 버튼 글자가 잘리지 않게 한다 (107)

### DIFF
--- a/core/ui/src/main/java/com/example/slowclock/ui/common/components/SignInPrompt.kt
+++ b/core/ui/src/main/java/com/example/slowclock/ui/common/components/SignInPrompt.kt
@@ -3,7 +3,7 @@ package com.example.slowclock.ui.common.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -66,12 +66,18 @@ fun SignInPrompt(
             Button(
                 onClick = onSignIn,
                 shape = RoundedCornerShape(16.dp),
+                // 글자 크기를 키운 기기에서 높이를 고정하면 버튼 글자가 잘린다(#107).
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .height(64.dp),
+                        .heightIn(min = 64.dp),
             ) {
-                Text(text = "Google 계정으로 로그인", style = MaterialTheme.typography.titleLarge)
+                Text(
+                    text = "Google 계정으로 로그인",
+                    style = MaterialTheme.typography.titleLarge,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
             }
         }
     }

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -126,11 +127,12 @@ internal fun AddScheduleContent(
                     onClick = { onIntent(AddScheduleIntent.Save) },
                     enabled = state.canSave,
                     shape = RoundedCornerShape(16.dp),
+                    // 글자 크기를 키운 기기에서 높이를 고정하면 버튼 글자가 잘린다(#107).
                     modifier =
                         Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 12.dp)
-                            .height(64.dp),
+                            .heightIn(min = 64.dp),
                 ) {
                     Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(28.dp))
                     Spacer(modifier = Modifier.size(8.dp))

--- a/feature/main/src/main/java/com/example/slowclock/ui/main/components/CurrentTaskSection.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/main/components/CurrentTaskSection.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -97,15 +98,17 @@ fun CurrentTaskSection(
             Box(
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                // 왼쪽 강조 바 (더 두껍게)
-                Box(
-                    modifier =
-                        Modifier
-                            .width(6.dp) // 4dp → 6dp
-                            .height(80.dp) // 60dp → 80dp
-                            .background(MaterialTheme.colorScheme.tertiary) // 하드코딩 색상 제거
-                            .align(Alignment.CenterStart),
-                )
+                // 왼쪽 강조 바. 높이를 고정하면 글자가 커져 카드가 길어질 때 바만 짧게 남는다(#107).
+                // 바깥 Box 가 카드 크기를 그대로 받고, 안쪽 바가 그 높이를 채운다.
+                Box(modifier = Modifier.matchParentSize()) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .width(6.dp)
+                                .fillMaxHeight()
+                                .background(MaterialTheme.colorScheme.tertiary),
+                    )
+                }
 
                 Row(
                     modifier =

--- a/feature/main/src/main/java/com/example/slowclock/ui/settings/SettingsScreen.kt
+++ b/feature/main/src/main/java/com/example/slowclock/ui/settings/SettingsScreen.kt
@@ -8,8 +8,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
@@ -17,15 +21,15 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -90,19 +94,48 @@ private fun ThemeModeCard(
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Spacer(modifier = Modifier.height(12.dp))
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                options.forEachIndexed { index, (mode, label) ->
-                    SegmentedButton(
+            // 가로로 나눈 세 칸은 글자 크기를 키우면 반드시 잘린다. 세로로 편다(#107).
+            Column(modifier = Modifier.selectableGroup()) {
+                options.forEach { (mode, label) ->
+                    ThemeModeRow(
+                        label = label,
                         selected = selected == mode,
-                        onClick = { onSelect(mode) },
-                        shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
-                        modifier = Modifier.height(56.dp),
-                    ) {
-                        Text(text = label, style = MaterialTheme.typography.titleMedium)
-                    }
+                        onSelect = { onSelect(mode) },
+                    )
                 }
             }
         }
+    }
+}
+
+/** 화면 밝기 선택 한 줄. 줄 전체가 눌리고, 글자가 커지면 줄도 같이 커진다. */
+@Composable
+private fun ThemeModeRow(
+    label: String,
+    selected: Boolean,
+    onSelect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .selectable(
+                    selected = selected,
+                    onClick = onSelect,
+                    role = Role.RadioButton,
+                ).heightIn(min = 56.dp)
+                .padding(horizontal = 4.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = null)
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
     }
 }
 


### PR DESCRIPTION
## 📌 Issues

closes #107

## 📎 Work Description

기기 글자 크기를 200% 로 올리면 버튼 글자가 잘렸습니다. 고령자를 위한 앱이라 글자 크기를 키운 기기가 오히려 기본입니다.

- 버튼 높이를 `Modifier.height(...)` 로 고정해 두어 글자가 커져도 높이가 늘지 않았습니다. `heightIn(min = ...)` 으로 바꿔 글자가 커지면 버튼도 커집니다. 최소 높이는 종전 값을 그대로 써서 터치 영역이 줄지 않습니다. 로그인 안내 버튼과 일정 저장 버튼에 적용했습니다.
- 화면 밝기 선택은 가로 세 칸이라 높이만으로는 풀리지 않습니다. 세로 세 줄 라디오 선택으로 폈습니다. 줄 전체가 눌리고 `selectableGroup` 으로 묶어 접근성 도구가 하나의 선택지 묶음으로 읽습니다.
- 현재 일정 카드의 왼쪽 강조 바도 높이가 고정이라 카드가 길어지면 바만 짧게 남았습니다. 카드 높이를 따라가게 고쳤습니다.

## 📷 Screenshot

에뮬레이터에서 `adb shell settings put system font_scale 2.0` 으로 확인했습니다.

고치기 전에는 로그인 버튼이 "Google 계정으로" 에서 잘리고 화면 밝기 첫 칸이 "기기 설" 로 잘렸습니다. 고친 뒤에는 로그인 버튼이 두 줄로 늘어 "Google 계정으로 로그인" 이 다 보이고, 화면 밝기는 기기 설정·밝게·어둡게 세 줄이 온전히 보입니다.

## 💬 To Reviewers

일정 저장 버튼은 로그인해야 닿는 화면이라 에뮬레이터에서 눈으로 확인하지 못했습니다. 고친 방식이 로그인 버튼과 같아서 같이 넣었습니다.

저장소 어디에도 `heightIn` 을 쓴 곳이 없었습니다. 같은 함정이 다시 생기지 않게 새 버튼은 최소 높이로 잡는 편이 좋겠습니다.
