### PR TITLE
fix: screenshot baseline 을 가진 모듈을 새로 만들 수 있게 한다 (111)

### DIFF
--- a/.github/scripts/screenshot-baseline-policy.test.mjs
+++ b/.github/scripts/screenshot-baseline-policy.test.mjs
@@ -42,21 +42,37 @@ test("the packaged baseline paths come from the same module list", () => {
     assert.match(generate, /src\/screenshotTestDebug\/reference/);
 });
 
-test("the apply lane accepts only the reference roots of modules that declare screenshot tests", async () => {
+test("the apply lane accepts only reference roots that belong to real modules", async () => {
     // apply 는 PR tree 를 checkout 하지 않고 artifact 의 PNG 만 커밋한다. 허용 경로가 실제
-    // screenshotTest 소스셋과 어긋나면 새 모듈의 골든이 조용히 거절되거나, 반대로 아무
-    // 경로나 커밋된다. 모듈 목록은 settings.gradle.kts 에서 읽어 손으로 적은 목록과 대조한다.
+    // 모듈과 어긋나면 아무 경로에나 커밋할 수 있게 된다. 모듈 목록은 settings.gradle.kts 에서
+    // 읽어 손으로 적은 목록과 대조한다.
+    //
+    // 정확히 같기를 요구하지는 않는다. 이 lane 은 기본 브랜치의 워크플로를 읽으므로 새 모듈의
+    // 경로는 그 모듈에 미리보기를 붙이는 PR 보다 먼저 올라와 있어야 한다. 그래서 아직
+    // screenshotTest 소스셋이 없는 모듈의 경로를 미리 적어 두는 것을 허용한다. 생성되는 PNG 가
+    // 없으니 허용 범위는 넓어지지 않는다(#111).
     const modules = await inspectModules(repoRoot);
-    const expected = modules
+    const withScreenshots = modules
         .filter(({ screenshot }) => screenshot)
         .map(({ directory }) => `${directory}/src/screenshotTestDebug/reference/`)
         .sort();
-    assert.ok(expected.length > 0, "screenshotTest 소스셋을 가진 모듈을 하나도 못 찾았다");
+    assert.ok(withScreenshots.length > 0, "screenshotTest 소스셋을 가진 모듈을 하나도 못 찾았다");
+
+    const allowedByModule = new Set(
+        modules.map(({ directory }) => `${directory}/src/screenshotTestDebug/reference/`),
+    );
 
     const rootsBlock = /const roots = \[\n((?:\s+'[^']+',\n)+)\s+\];/.exec(apply)?.[1];
     assert.ok(rootsBlock, "apply 워크플로의 roots 목록을 찾지 못했다");
     const declared = [...rootsBlock.matchAll(/'([^']+)'/g)].map((match) => match[1]).sort();
-    assert.deepEqual(declared, expected);
+
+    for (const root of withScreenshots) {
+        assert.ok(declared.includes(root), `미리보기가 있는 모듈의 경로가 빠졌다: ${root}`);
+    }
+    for (const root of declared) {
+        assert.ok(allowedByModule.has(root), `저장소에 없는 모듈의 경로다: ${root}`);
+    }
+    assert.equal(new Set(declared).size, declared.length, "중복된 경로가 있다");
 });
 
 test("a run that can generate nothing fails loudly", () => {

--- a/.github/workflows/screenshot-baseline-apply.yml
+++ b/.github/workflows/screenshot-baseline-apply.yml
@@ -100,10 +100,14 @@ jobs:
           script: |
             const fs = require('node:fs');
             const path = require('node:path');
-            // screenshotTest 소스셋을 가진 모듈의 reference 경로. 모듈이 늘면 여기와
-            // screenshot-baseline-policy.test.mjs 를 함께 늘린다.
+            // baseline 을 커밋해도 되는 자리. 이 lane 은 workflow_run 으로 돌아 PR 브랜치가
+            // 아니라 기본 브랜치의 이 파일을 읽는다. 그래서 새 모듈의 경로는 그 모듈에
+            // 미리보기를 붙이는 PR 보다 먼저 main 에 올라와 있어야 한다. 아직 미리보기가 없는
+            // 모듈의 경로를 미리 적어 두는 것은 허용한다. 생성되는 PNG 가 없으므로 허용 범위가
+            // 넓어지지 않는다(#111).
             const roots = [
               'app/src/screenshotTestDebug/reference/',
+              'feature/main/src/screenshotTestDebug/reference/',
             ];
             const artifact = path.resolve(process.env.ARTIFACT_DIR);
             const filesPath = path.join(artifact, 'files.json');


### PR DESCRIPTION
## 📌 Issues

closes #111

## 📎 Work Description

새 모듈에 Compose 미리보기 스크린샷을 붙일 수 없었습니다. #109 에서 `feature/main` 에 붙였다가 baseline 적용 단계에서 막혔습니다.

```
Rejected non-baseline or duplicate path: feature/main/src/screenshotTestDebug/reference/...
```

- baseline 을 커밋하는 lane 은 `workflow_run` 으로 돌아 PR 브랜치가 아니라 기본 브랜치의 워크플로 파일을 읽습니다. 허용 경로가 손으로 적혀 있어, PR 에서 함께 고쳐도 그 PR 에서는 반영되지 않습니다.
- 그렇다고 먼저 올릴 수도 없었습니다. 정책 테스트가 허용 목록과 실제 미리보기 모듈을 정확히 같게 요구해서, 아직 미리보기가 없는 모듈의 경로를 미리 적으면 실패합니다.

고친 내용입니다.

- 허용 목록에 `feature/main` 의 reference 경로를 더했습니다.
- 정책 테스트를 "정확히 같다" 에서 두 가지 확인으로 바꿨습니다. 미리보기가 있는 모듈의 경로가 모두 목록에 있어야 하고, 목록에 있는 경로는 모두 실재하는 모듈의 것이어야 합니다. 중복도 막습니다.
- 순서 문제 자체를 워크플로 주석에 남겼습니다.

## 📷 Screenshot

워크플로와 테스트만 고쳐 화면 변경이 없습니다.

## 💬 To Reviewers

허용 목록은 커밋할 수 있는 자리를 좁히는 장치입니다. 아직 아무 PNG 도 생성되지 않는 경로가 미리 적혀 있어도 커밋할 수 있는 범위는 넓어지지 않습니다. 저장소에 없는 모듈 경로는 그대로 거절합니다.

머지한 뒤 #109 에 `screenshot-baseline` 라벨을 다시 달면 그 PR 의 baseline 이 CI 컨테이너에서 만들어집니다.
