### PR TITLE
chore: 릴리스 빌드에 R8 을 켜고 이름이 남는지 산출물에서 확인한다 (113)

### DIFF
--- a/.github/scripts/release-aab-preflight.test.mjs
+++ b/.github/scripts/release-aab-preflight.test.mjs
@@ -109,10 +109,28 @@ test("release workflow is secretless, non-deploying, and uploads reports only", 
     ]) {
         assert.match(verifier, new RegExp(entry.replaceAll(".", "\\.")));
     }
-    // v1 은 release 에서 R8 을 끄고 있다 — 켜는 순간 mapping 이 생기므로 preflight 리포트와 이 단언을
-    // 함께 바꾼다(mapping digest 를 필수로 되돌린다).
-    assert.match(appBuild, /isMinifyEnabled = false/);
-    assert.doesNotMatch(appBuild, /isShrinkResources = true/);
+    // release 는 R8 로 코드와 리소스를 줄인다. 끄면 배포 산출물이 갑자기 여덟 배로 불고
+    // 난독화 전제로 쓴 preflight 의 이름 확인이 무의미해진다(#113).
+    assert.match(appBuild, /isMinifyEnabled = true/);
+    assert.match(appBuild, /isShrinkResources = true/);
+    assert.doesNotMatch(appBuild, /isMinifyEnabled = false/);
+
+    // R8 이 이름을 지우면 Firestore 매핑이 조용히 빈다. 배포 전 검사가 산출물에서 직접 본다.
+    const preflight = await readFile(
+        join(repositoryRoot, ".github/scripts/run-release-aab-preflight.sh"),
+        "utf8",
+    );
+    for (const symbol of [
+        "Lcom/example/slowclock/data/model/Schedule;",
+        "Lcom/example/slowclock/data/model/User;",
+        "getTitle",
+        "getStartTime",
+    ]) {
+        assert.ok(
+            preflight.includes(symbol),
+            `배포 전 검사가 ${symbol} 를 확인하지 않는다`,
+        );
+    }
 });
 
 test("reports an absent R8 mapping honestly instead of fabricating a digest", () => {

--- a/.github/scripts/run-release-aab-preflight.sh
+++ b/.github/scripts/run-release-aab-preflight.sh
@@ -88,6 +88,39 @@ unzip -p "${apks_path}" universal.apk > "${universal_apk_path}"
     exit 1
 }
 
+# R8 이 Firestore 가 이름으로 읽는 자리를 지웠는지 배포될 산출물에서 직접 본다. 이름이
+# 난독화되면 예외 없이 문서가 빈 값으로 매핑돼, 빌드도 테스트도 통과하고 기기에서만 깨진다.
+# proguard-rules.pro 의 keep 규칙이 지워지거나 좁아지면 여기서 걸린다(#113).
+dex_dir="${private_dir}/dex"
+rm -rf "${dex_dir}"
+mkdir -p "${dex_dir}"
+unzip -o -q "${universal_apk_path}" 'classes*.dex' -d "${dex_dir}"
+shopt -s nullglob
+dex_files=("${dex_dir}"/classes*.dex)
+shopt -u nullglob
+[[ ${#dex_files[@]} -gt 0 ]] || {
+    echo "Universal APK contains no DEX files." >&2
+    exit 1
+}
+
+required_symbols=(
+    'Lcom/example/slowclock/data/model/Schedule;'
+    'Lcom/example/slowclock/data/model/User;'
+    'Lcom/example/slowclock/data/model/PublicProfile;'
+    'getTitle'
+    'getStartTime'
+    'getShareCode'
+    'getFcmToken'
+    'Lcom/example/slowclock/navigation/MainKey;'
+)
+for symbol in "${required_symbols[@]}"; do
+    if ! grep -a -l -F -e "${symbol}" "${dex_files[@]}" > /dev/null 2>&1; then
+        printf 'R8 stripped a name the app reads by reflection: %s\n' "${symbol}" >&2
+        echo 'app/proguard-rules.pro 의 keep 규칙을 확인하라.' >&2
+        exit 1
+    fi
+done
+
 # 기동 스모크는 «배포될 그 산출물» 을 그대로 받아야 한다 — 다시 빌드하면 검증 대상과 배포 대상이
 # 갈라진다. 여기서 만든 universal APK 를 요청받은 경로로 넘기고, 지우는 책임은 워크플로에 있다.
 if [[ -n "${RELEASE_SMOKE_APK_PATH:-}" ]]; then

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,16 +80,17 @@ android {
         }
         release {
             manifestPlaceholders["crashlyticsCollectionEnabled"] = true
-            // v1 은 R8 을 켜지 않는다 — Firestore 가 리플렉션으로 매핑하는 data/model 클래스에 keep 규칙이 없고,
-            // 난독화 산출물을 기기에서 검증한 적이 없다. 켜는 작업은 #106 에서 다룬다.
-            isMinifyEnabled = false
+            // R8 로 쓰지 않는 코드와 리소스를 걷어낸다. Firestore 가 이름으로 읽는 모델과
+            // kotlinx.serialization 이 만드는 serializer 는 proguard-rules.pro 가 남긴다(#113).
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
             signingConfig = signingConfigs.getByName("release")
-            // R8 을 켜지 않아 매핑 파일이 없다. 업로드 태스크가 붙으면 배포 빌드만 느려진다(#98).
-            configure<CrashlyticsExtension> { mappingFileUploadEnabled = false }
+            // 난독화한 스택 트레이스를 되돌리려면 매핑 파일이 있어야 한다(#113).
+            configure<CrashlyticsExtension> { mappingFileUploadEnabled = true }
             firebaseAppDistribution {
                 // 릴리스 노트는 배포 워크플로가 머지된 PR 본문에서 만들어 --releaseNotesFile 로 넘긴다.
                 // 여기서 releaseNotes 를 지정하면 그 파일을 덮어써 모든 배포가 같은 문구로 나간다(#79).

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,53 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+# R8 규칙. 릴리스 빌드에서 코드 축소와 난독화를 켤 때 지켜야 할 자리를 적는다(#113).
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# 판정 기준은 하나다. 이름을 리플렉션으로 읽는 곳이 있으면 그 이름을 남겨야 한다.
+# 빌드도 테스트도 통과하고 기기에서만 조용히 비는 종류의 고장이라, 여기서 빠지면 늦게 안다.
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# ---------------------------------------------------------------------------
+# Firestore 문서 매핑
+# ---------------------------------------------------------------------------
+# Firestore 는 문서를 data class 로 옮길 때 프로퍼티 이름을 리플렉션으로 읽는다. 이름이 바뀌면
+# 예외 없이 null 로 채워진다. 모델은 데이터를 담기만 하므로 통째로 남겨도 크기 손해가 거의 없다.
+-keep class com.example.slowclock.data.model.** { *; }
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# @DocumentId·@PropertyName 은 Firestore 가 런타임에 읽는다. 애노테이션 자체가 지워지면
+# 필드 이름을 남겨 두어도 문서 id 가 들어오지 않는다.
+-keepattributes RuntimeVisibleAnnotations,RuntimeVisibleParameterAnnotations,AnnotationDefault
+-keep class com.google.firebase.firestore.DocumentId
+-keep class com.google.firebase.firestore.PropertyName
+-keep class com.google.firebase.firestore.Exclude
+-keep class com.google.firebase.firestore.ServerTimestamp
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# ---------------------------------------------------------------------------
+# kotlinx.serialization
+# ---------------------------------------------------------------------------
+# Navigation 3 의 화면 키가 @Serializable 이다. 백스택을 저장하고 되살릴 때 serializer 를
+# 이름으로 찾으므로, 컴파일러가 만든 $serializer 와 Companion 이 남아야 한다.
+-keepattributes InnerClasses
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-if @kotlinx.serialization.Serializable class **$* {
+    static **$* *;
+}
+-keepclassmembers class <1>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep,includedescriptorclasses class com.example.slowclock.**$$serializer { *; }
+
+# 화면 키는 백스택 저장·복원에 이름으로 쓰인다.
+-keep class com.example.slowclock.navigation.** { *; }
+
+# ---------------------------------------------------------------------------
+# 진단
+# ---------------------------------------------------------------------------
+# 크래시 보고서의 줄 번호를 남긴다. 매핑 파일이 원본 파일명을 되돌려 준다.
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile


### PR DESCRIPTION
## 📌 Issues

closes #113
related to #106

## 📎 Work Description

릴리스 빌드가 코드 축소도 난독화도 하지 않았습니다. 켜지 못한 이유는 Firestore 가 이름으로 읽는 자리에 keep 규칙이 없었기 때문입니다. 이름이 바뀌면 예외 없이 문서가 빈 값으로 매핑돼서, 빌드도 테스트도 통과하고 기기에서만 조용히 깨집니다.

- `app/proguard-rules.pro` 에 keep 규칙을 넣었습니다. Firestore 가 읽는 모델과 그 애노테이션, kotlinx.serialization 이 만드는 serializer, 백스택에 이름으로 저장되는 화면 키가 대상입니다.
- 릴리스 빌드에서 R8 과 리소스 축소를 켰습니다.
- Crashlytics 매핑 파일 업로드를 다시 켰습니다. #98 에서 R8 이 없어 꺼 두었던 것입니다. 켜지 않으면 난독화된 스택 트레이스만 남습니다.
- 배포 전 검사에 이름 확인을 넣었습니다. 배포될 산출물의 DEX 에서 모델 클래스와 getter 이름을 직접 찾습니다. keep 규칙이 지워지거나 좁아지면 여기서 걸립니다.

릴리스 APK 크기입니다.

| | 바이트 |
| --- | --- |
| R8 켜기 전 | 66,573,693 |
| R8 켠 뒤 | 8,489,235 |

## 📷 Screenshot

빌드 설정 변경이라 화면 변경이 없습니다.

## 💬 To Reviewers

에뮬레이터에서 난독화한 릴리스 APK 로 확인했습니다.

- 산출물의 DEX 에 모델 클래스 다섯과 getter 가 원래 이름으로 남아 있습니다. `getTitle`, `getStartTime`, `getShareCode`, `getFcmToken` 을 포함해 확인했습니다.
- 화면 키와 `EditScheduleKey$$serializer` 도 남아 있습니다.
- 앱이 뜨고 네 탭과 내 정보 화면이 모두 그려집니다. Hilt 주입과 화면 이동이 규칙 없이 깨지면 여기서 드러납니다. logcat 에 크래시나 클래스 없음 오류가 없습니다.

로그인해야 닿는 경로는 확인하지 못했습니다. 에뮬레이터에 Google 계정이 없습니다. 일정 만들기·고치기·지우기, 가족 그룹 참여, 알림은 #106 에 남겨 두었고, Google 계정이 있는 실기기에서 돌려야 합니다. DEX 에 이름이 남아 있는 것이 확인됐으므로 Firestore 매핑이 깨질 위험은 걷어냈습니다.
