### PR TITLE
fix: 워크플로를 안 건드리는 PR 에서 CodeQL 검사가 빨개지지 않게 한다 (119)

### DIFF
--- a/.github/scripts/codeql-path-scope-policy.test.mjs
+++ b/.github/scripts/codeql-path-scope-policy.test.mjs
@@ -33,7 +33,6 @@ test("CodeQL classifies every PR file by language and defaults to full analysis"
     assert.match(classifier, /classify-documentation-changes\.mjs/);
     assert.match(classifier, /docs_only=.*classify-documentation-changes\.mjs/s);
     assert.match(classifier, /resolve-pr-impact\.mjs/);
-    assert.match(classifier, /actions_required: \$\{\{ steps\.path-scope\.outputs\.codeql_actions \|\| 'true' \}\}/);
     assert.match(classifier, /javascript_typescript_required: \$\{\{ steps\.path-scope\.outputs\.codeql_javascript_typescript \|\| 'true' \}\}/);
     assert.match(classifier, /java_kotlin_required: \$\{\{ steps\.path-scope\.outputs\.codeql_java_kotlin \|\| 'true' \}\}/);
     assert.match(classifier, /codeql_javascript_typescript=false/);
@@ -51,7 +50,9 @@ test("CodeQL preserves all required context names and skips only an unaffected l
     const actions = jobBlock(source, "analyze-actions", "analyze-javascript-typescript");
     const javascript = jobBlock(source, "analyze-javascript-typescript", "analyze-java-kotlin");
     const kotlin = jobBlock(source, "analyze-java-kotlin");
-    const actionsFailClosed = /if: \$\{\{ !cancelled\(\) && \(needs\.classify-changes\.result != 'success' \|\| needs\.classify-changes\.outputs\.actions_required != 'false'\) \}\}/;
+    // actions 분석은 건너뛰지 않는다. 건너뛰면 코드 스캐닝이 모으는 검사가 «설정을
+    // 못 찾았다» 로 실패해, 새 경고 없는 PR 이 빨개진다(#119).
+    const actionsAlwaysRuns = /if: \$\{\{ !cancelled\(\) \}\}/;
     const javascriptFailClosed = /if: \$\{\{ !cancelled\(\) && \(needs\.classify-changes\.result != 'success' \|\| needs\.classify-changes\.outputs\.javascript_typescript_required != 'false'\) \}\}/;
     const kotlinFailClosed = /if: \$\{\{ !cancelled\(\) && \(needs\.classify-changes\.result != 'success' \|\| needs\.classify-changes\.outputs\.java_kotlin_required != 'false'\) \}\}/;
 
@@ -61,7 +62,8 @@ test("CodeQL preserves all required context names and skips only an unaffected l
     assert.match(actions, /^\s{4}needs: classify-changes$/m);
     assert.match(javascript, /^\s{4}needs: classify-changes$/m);
     assert.match(kotlin, /^\s{4}needs: classify-changes$/m);
-    assert.match(actions, actionsFailClosed);
+    assert.match(actions, actionsAlwaysRuns);
+    assert.doesNotMatch(actions, /actions_required/);
     assert.match(javascript, javascriptFailClosed);
     assert.match(kotlin, kotlinFailClosed);
     assert.match(actions, /security-events: write/);

--- a/.github/scripts/resolve-pr-impact.mjs
+++ b/.github/scripts/resolve-pr-impact.mjs
@@ -157,7 +157,6 @@ export function resolvePrImpact(changedFiles, modules, dependencies) {
     let screenshotInfrastructureChange = false;
     let compileAndroidTest = false;
     let runNodeTests = false;
-    let codeqlActions = false;
     let codeqlJavaKotlin = false;
     let forceFull = false;
     let repositoryQualityFixtures = false;
@@ -207,7 +206,6 @@ export function resolvePrImpact(changedFiles, modules, dependencies) {
             runNodeTests = true;
         }
         if (filePath.startsWith(".github/workflows/") || filePath.startsWith(".github/actions/")) {
-            codeqlActions = true;
         }
         if (filePath === ".editorconfig") {
             globalKtlintChange = true;
@@ -262,7 +260,6 @@ export function resolvePrImpact(changedFiles, modules, dependencies) {
         globalKtlintChange = true;
         screenshotInfrastructureChange = true;
         runNodeTests = true;
-        codeqlActions = true;
         codeqlJavaKotlin = true;
         compileAndroidTest = true;
     }
@@ -328,7 +325,6 @@ export function resolvePrImpact(changedFiles, modules, dependencies) {
         unitTestModules,
         screenshotModules,
         screenshotTasks,
-        codeqlActions,
         codeqlJavaKotlin,
         repositoryQualityFull: forceFull,
         repositoryQualityFixtures,
@@ -403,7 +399,6 @@ export function githubOutputLines(impact) {
         screenshot_required: impact.screenshotTasks.length > 0,
         screenshot_modules: impact.screenshotModules.join(" "),
         screenshot_tasks: impact.screenshotTasks.join(" "),
-        codeql_actions: impact.codeqlActions,
         codeql_java_kotlin: impact.codeqlJavaKotlin,
         repository_quality_full: impact.repositoryQualityFull,
         repository_quality_fixtures: impact.repositoryQualityFixtures,

--- a/.github/scripts/resolve-pr-impact.test.mjs
+++ b/.github/scripts/resolve-pr-impact.test.mjs
@@ -96,7 +96,6 @@ test("a production change fans out to every reverse-dependent module", () => {
     assert.deepEqual(impact.screenshotModules, [":app"]);
     assert.deepEqual(impact.screenshotTasks, [":app:validateScreenshotTest"]);
     assert.equal(impact.codeqlJavaKotlin, true);
-    assert.equal(impact.codeqlActions, false);
     assert.equal(impact.runNodeTests, false);
     assert.equal(impact.repositoryQualityFull, false);
 });
@@ -158,7 +157,6 @@ test("documentation-only changes select no Gradle work", () => {
         "screenshot_required=false",
         "screenshot_modules=",
         "screenshot_tasks=",
-        "codeql_actions=false",
         "codeql_java_kotlin=false",
         "repository_quality_full=false",
         "repository_quality_fixtures=false",
@@ -169,7 +167,6 @@ test("workflow, action and script changes run the policy tests and Actions CodeQ
     const impact = resolvePrImpact([".github/workflows/lint.yml", ".github/scripts/render-ktlint-summary.mjs"], modules, dependencies);
 
     assert.equal(impact.runNodeTests, true);
-    assert.equal(impact.codeqlActions, true);
     // lint.yml 은 영향 계산 정책 경로라 모든 lane 을 fail-closed 로 연다.
     assert.equal(impact.repositoryQualityFull, true);
     assert.deepEqual(impact.ktlintTasks, ["ktlintCheck"]);

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,6 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      actions_required: ${{ steps.path-scope.outputs.codeql_actions || 'true' }}
       javascript_typescript_required: ${{ steps.path-scope.outputs.codeql_javascript_typescript || 'true' }}
       java_kotlin_required: ${{ steps.path-scope.outputs.codeql_java_kotlin || 'true' }}
     steps:
@@ -121,7 +120,11 @@ jobs:
   analyze-actions:
     name: Analyze (actions)
     needs: classify-changes
-    if: ${{ !cancelled() && (needs.classify-changes.result != 'success' || needs.classify-changes.outputs.actions_required != 'false') }}
+    # 이 분석만 건너뛰지 않는다. 코드 스캐닝이 모으는 CodeQL 검사는 기본 브랜치에 있던 설정이
+    # 이 PR 에서 안 돌면 «configuration not found» 로 실패한다. 앱 코드만 고친 PR 이 새 경고
+    # 하나 없이 빨개져 진짜 실패와 구별되지 않았다(#119). 대상이 워크플로 파일 몇 개뿐이라
+    # 늘 돌려도 아끼는 값이 크지 않다. 무거운 자바·코틀린과 자바스크립트 분석은 그대로 가른다.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/repository-quality.yml
+++ b/.github/workflows/repository-quality.yml
@@ -45,9 +45,6 @@ on:
       screenshot_tasks:
         description: "영향받는 screenshot 검증 task 목록"
         value: ${{ jobs.repository-quality.outputs.screenshot_tasks }}
-      codeql_actions:
-        description: "Actions CodeQL 분석이 필요한지 여부"
-        value: ${{ jobs.repository-quality.outputs.codeql_actions }}
       codeql_java_kotlin:
         description: "Java/Kotlin CodeQL 분석이 필요한지 여부"
         value: ${{ jobs.repository-quality.outputs.codeql_java_kotlin }}
@@ -81,7 +78,6 @@ jobs:
       screenshot_required: ${{ steps.classify-documentation-changes.outputs.screenshot_required }}
       screenshot_modules: ${{ steps.classify-documentation-changes.outputs.screenshot_modules }}
       screenshot_tasks: ${{ steps.classify-documentation-changes.outputs.screenshot_tasks }}
-      codeql_actions: ${{ steps.classify-documentation-changes.outputs.codeql_actions }}
       codeql_java_kotlin: ${{ steps.classify-documentation-changes.outputs.codeql_java_kotlin }}
     steps:
       - name: Clone repo


### PR DESCRIPTION
## 📌 Issues

closes #119

## 📎 Work Description

앱 코드만 고친 PR 에서 CodeQL 검사가 빨갛게 떴습니다. 새 경고를 찾아서가 아니라, 기본 브랜치에 있는 분석 설정 하나를 그 PR 에서 돌리지 않아서입니다. #118 에서 실측했고, 검사 요약이 스스로 이렇게 말합니다.

```
1 configuration not found

Warning: Code scanning may not have found all the alerts introduced by this
pull request, because 1 configuration present on refs/heads/main was not found:

  Actions workflow (codeql.yml)
    /language:actions

New alerts in code changed by this pull request
Security Alerts:
```

새 경고 목록은 비어 있습니다. 실패의 이유는 `Analyze (actions)` 가 건너뛰어졌다는 것뿐입니다.

- actions 분석을 항상 돌립니다. 대상이 워크플로 파일 몇 개뿐이라 아끼는 값이 크지 않습니다.
- 자바·코틀린과 자바스크립트 분석의 건너뛰기는 그대로 뒀습니다. 그쪽은 실제로 무겁습니다.
- 더 이상 쓰지 않는 `codeql_actions` 판정과 그 출력을 걷어냈습니다.
- 왜 이 하나만 건너뛰지 않는지 워크플로 주석에 남겼습니다.

## 📷 Screenshot

CI 설정 변경이라 화면 변경이 없습니다.

## 💬 To Reviewers

정책 테스트를 새 모양에 맞췄습니다. actions 작업이 `!cancelled()` 로만 걸리는지, `actions_required` 를 더 읽지 않는지 확인합니다. 노드 테스트 241개가 통과합니다.

앞으로 앱 코드만 고치는 PR 은 이 자리에서 빨개지지 않습니다. 자바·코틀린 쪽에서 같은 증상이 나오면 그때는 그 건너뛰기 자체를 다시 봐야 합니다.
