### PR TITLE
fix: 알람 Intent 의 대상을 정적 분석이 읽을 수 있게 한 번 더 지정한다 (121)

### DIFF
--- a/core/alarm/src/main/java/com/example/slowclock/core/alarm/ScheduleAlarmHelper.kt
+++ b/core/alarm/src/main/java/com/example/slowclock/core/alarm/ScheduleAlarmHelper.kt
@@ -53,6 +53,13 @@ object ScheduleAlarmHelper {
      * Intent 만들기부터 AlarmManager 호출까지 한 함수 안에 둔다. 나눠 두면 정적 분석이 대상
      * 컴포넌트를 따라가지 못해 「암시적 PendingIntent」 로 본다. 실제로는 [AlarmReceiver] 로
      * 못박혀 있고 FLAG_IMMUTABLE 이라 받는 쪽이 고칠 수도 없다(#117).
+     *
+     * 생성자로 대상을 준 뒤 `setClass` 로 한 번 더 지정한다. 중복처럼 보이지만 지우면 안 된다.
+     * CodeQL 의 Kotlin 추출기(K2)가 `Intent(Context, Class)` 의 둘째 인자를 데이터베이스에
+     * 남기지 않아, 생성자만으로는 대상이 명시적이라는 것을 증명하지 못한다(github/codeql#20153).
+     * `setClass` 호출은 인자 타입을 보지 않는 갈래로 판정되어 그 자리를 세운다(#121).
+     * 런타임 동작은 같다. 두 방법이 만드는 ComponentName 이 같고, 알람 취소가 대상을 맞추는
+     * `filterEquals` 도 그 값만 본다. 그래서 예약과 취소가 계속 같은 자리를 가리킨다.
      */
     private fun scheduleOne(
         context: Context,
@@ -70,13 +77,16 @@ object ScheduleAlarmHelper {
 
         val requestCode = requestCodeOf(schedule.id, kind)
         val intent =
-            Intent(context, AlarmReceiver::class.java).apply {
-                putExtra("title", "${schedule.title} (${kind.label})")
-                putExtra("desc", schedule.description)
-                putExtra("isFullScreen", isFullScreen)
-                putExtra("scheduleId", schedule.id)
-                putExtra("alarmType", kind.label)
-            }
+            Intent(context, AlarmReceiver::class.java)
+                // 대상을 한 번 더 못박는다. 중복이 아니라 정적 분석을 위한 것이다(#121).
+                .setClass(context, AlarmReceiver::class.java)
+                .apply {
+                    putExtra("title", "${schedule.title} (${kind.label})")
+                    putExtra("desc", schedule.description)
+                    putExtra("isFullScreen", isFullScreen)
+                    putExtra("scheduleId", schedule.id)
+                    putExtra("alarmType", kind.label)
+                }
         val pendingIntent =
             PendingIntent.getBroadcast(
                 context,
@@ -122,12 +132,15 @@ object ScheduleAlarmHelper {
         val requestCode = requestCodeOf(schedule.id, kind)
         try {
             val intent =
-                Intent(context, AlarmReceiver::class.java).apply {
-                    putExtra("title", "${schedule.title} (${kind.label})")
-                    putExtra("desc", schedule.description)
-                    putExtra("scheduleId", schedule.id)
-                    putExtra("alarmType", kind.label)
-                }
+                Intent(context, AlarmReceiver::class.java)
+                    // 예약 쪽과 같은 이유로 대상을 다시 지정한다(#121).
+                    .setClass(context, AlarmReceiver::class.java)
+                    .apply {
+                        putExtra("title", "${schedule.title} (${kind.label})")
+                        putExtra("desc", schedule.description)
+                        putExtra("scheduleId", schedule.id)
+                        putExtra("alarmType", kind.label)
+                    }
             val pendingIntent =
                 PendingIntent.getBroadcast(
                     context,


### PR DESCRIPTION
## 📌 Issues

closes #121

## 📎 Work Description

CodeQL 이 알람 PendingIntent 를 「암시적 PendingIntent」(high)로 잡아 왔습니다. main 에 열린 채 남아 있어서 이 파일을 건드리는 PR 마다 검사가 빨개졌습니다.

원인을 찾았습니다. 대상은 원래부터 명시적입니다. 다만 CodeQL 의 Kotlin 추출기(K2)가 `Intent(Context, Class)` 의 둘째 인자를 데이터베이스에 남기지 않아, 생성자만으로는 그 사실을 증명하지 못합니다. 업스트림에 열린 이슈입니다.

- github/codeql#20153: false-positive 라벨이 붙어 열려 있습니다
- github/codeql#21915: 고치는 PR 이지만 아직 머지되지 않았습니다

생성자 뒤에 `setClass` 를 체이닝했습니다. 이 호출은 인자 타입을 보지 않는 갈래로 판정되어 대상이 명시적이라는 사실이 분석에 남습니다.

런타임 동작은 같습니다. `Intent(Context, Class)` 와 `setClass(Context, Class)` 가 만드는 `ComponentName` 이 같은 값이고, 알람 취소가 대상을 맞추는 `filterEquals` 도 그 값만 봅니다. 예약과 취소가 계속 같은 자리를 가리킵니다.

## 📷 Screenshot

화면 변경이 없습니다.

## 💬 To Reviewers

`setPackage` 로도 같은 갈래를 세울 수 있지만 쓰지 않았습니다. `filterEquals` 가 패키지도 비교하므로, 이미 걸려 있던 알람을 취소하지 못하는 고아를 만듭니다. 예약과 취소를 함께 바꿔도 업그레이드 전에 걸린 알람은 영영 남습니다.

플래그 쪽도 건드리지 않았습니다. `FLAG_UPDATE_CURRENT` 를 빼면 제목을 고쳐도 옛 내용으로 울립니다.

이 변경이 실제로 통하는지는 이 PR 의 CodeQL 실행이 유일한 판정입니다. 로컬에 CodeQL 이 없습니다. 여전히 잡히면 CodeQL 자체 테스트와 같은 문장형으로 한 번 더 시도하고, 그래도 안 되면 오탐으로 정리하겠습니다.

업스트림 PR 이 머지되어 러너에 실리면 이 `setClass` 는 지워도 되는 잔재가 됩니다. 주석에 그 사정을 적어 두었습니다.
