### PR TITLE
fix: 내 정보 화면이 큰 글자에서도 끝까지 보이게 한다 (135)

### DIFF
--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
@@ -5,8 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Person
@@ -120,7 +124,11 @@ internal fun ProfileContent(
                 Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
+                    // 글자를 크게 쓰면 아이콘과 이름과 공유 코드만으로 화면이 차서 아래 버튼이
+                    // 밀려난다. 스크롤이 없으면 로그아웃도 계정 삭제도 할 수 없다(#135).
+                    .verticalScroll(rememberScrollState())
                     .padding(24.dp),
+            // 내용이 짧을 때만 가운데로 모인다. 넘치면 위에서부터 그려지고 스크롤로 닿는다.
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -202,7 +210,8 @@ private fun ProfileBody(
                 ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.error,
                 ),
-            modifier = Modifier.size(width = 200.dp, height = 56.dp),
+            // 높이를 고정하면 글자 배율을 올렸을 때 글자가 위아래로 잘린다(#107 과 같은 함정).
+            modifier = Modifier.widthIn(min = 200.dp).heightIn(min = 64.dp),
         ) {
             Text(
                 text = "로그아웃",
@@ -224,7 +233,7 @@ private fun ProfileBody(
         } else {
             TextButton(
                 onClick = { onIntent(ProfileIntent.RequestDeleteAccount) },
-                modifier = Modifier.size(width = 200.dp, height = 56.dp),
+                modifier = Modifier.widthIn(min = 200.dp).heightIn(min = 64.dp),
             ) {
                 Text(
                     text = "계정 삭제",


### PR DESCRIPTION
## 📌 Issues

Closes #135

## 📎 Work Description

글자를 크게 쓰는 사용자가 내 정보 화면에서 로그아웃도 계정 삭제도 할 수 없었습니다. 두 가지가 겹쳐 있었습니다.

**버튼 높이가 56dp 로 고정돼 있었습니다.** 안의 글자가 `bodyLarge`(20sp, 줄 높이 28sp)이고 Button 기본 세로 여백을 빼면 글자에 40dp 밖에 안 남습니다. 글자 배율 2.0 이면 줄 높이가 56sp 로 늘어 위아래가 잘립니다. `heightIn(min = 64.dp)` 과 `widthIn(min = 200.dp)` 으로 바꿨습니다. `AddScheduleScreen` 이 #107 에서 같은 함정을 같은 방법으로 고친 자리가 있습니다.

**화면에 스크롤이 없었습니다.** 바깥 `Column` 이 `Arrangement.Center` 인데 세로 스크롤이 없어서, 120dp 아이콘과 이름과 이메일과 공유 코드만으로도 기본 배율에서 500dp 를 넘고 큰 배율에서는 화면을 확실히 넘칩니다. 가운데 정렬이라 넘친 만큼 위아래가 함께 잘리고 되찾을 방법이 없었습니다. `verticalScroll` 을 걸었습니다. 내용이 짧을 때는 지금처럼 가운데로 모이고, 넘치면 위에서부터 그려지며 스크롤로 닿습니다.

## 📷 Screenshot

`feature/profile` 에는 스크린샷 테스트가 없어 baseline 변화가 없습니다.

## 💬 To Reviewers

- 로컬 검증: `ktlintFormat` · `testDebugUnitTest`(전 모듈) · `:app:lintDebug` 초록입니다.
- 같은 고정 높이가 다른 화면에 남아 있는지 훑었습니다. `Modifier.size(width =, height =)` 로 버튼 높이를 박은 자리는 이 화면 둘뿐이었습니다.
