### PR TITLE
fix: 알람이 겹쳐도 각각 보이고 화면이 스스로 닫히게 한다 (131)

### DIFF
--- a/core/alarm/src/main/java/com/example/slowclock/ui/alarm/AlarmFullScreenActivity.kt
+++ b/core/alarm/src/main/java/com/example/slowclock/ui/alarm/AlarmFullScreenActivity.kt
@@ -1,6 +1,10 @@
 package com.example.slowclock.ui.alarm
 
 import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -11,6 +15,7 @@ import android.widget.Button
 import android.widget.TextView
 import android.window.OnBackInvokedCallback
 import android.window.OnBackInvokedDispatcher
+import androidx.core.content.ContextCompat
 import com.example.slowclock.core.alarm.R
 import com.example.slowclock.core.alarm.SnoozePolicy
 import java.text.SimpleDateFormat
@@ -19,6 +24,23 @@ import java.util.*
 class AlarmFullScreenActivity : Activity() {
     private val timeHandler = Handler(Looper.getMainLooper())
     private lateinit var timeRunnable: Runnable
+
+    /**
+     * 서비스가 알람 울리기를 끝냈다는 신호. 받으면 이 화면도 닫는다.
+     *
+     * 종전에는 이 화면을 끝내는 길이 닫기 버튼 하나뿐이었다. 서비스가 5분 뒤 스스로 멈춰도
+     * 화면은 그대로 남아, `FLAG_KEEP_SCREEN_ON` 때문에 아침까지 켜진 채 1초마다 시계를 다시
+     * 그렸다. 뒤로가기는 막혀 있고 최근 앱에도 없어 홈 버튼 말고는 치울 방법이 없었다(#131).
+     */
+    private val ringingFinishedReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                context: Context?,
+                intent: Intent?,
+            ) {
+                finish()
+            }
+        }
 
     // 알람은 닫기 버튼으로만 끈다. targetSdk 36 부터 predictive back 이 기본이라
     // API 33 이상에서는 onBackPressed 가 불리지 않으므로 여기서 제스처를 삼킨다.
@@ -50,20 +72,14 @@ class AlarmFullScreenActivity : Activity() {
             finish()
         }
 
-        // 다시 알림. 예약도 소리 끄기도 서비스가 한다. 화면은 시키기만 한다(#122 와 같은 자리).
-        val snoozeCount = intent.getIntExtra(AlarmTriggerService.EXTRA_SNOOZE_COUNT, 0)
-        val snoozeButton = findViewById<Button>(R.id.snoozeButton)
-        if (SnoozePolicy.canSnooze(snoozeCount)) {
-            // 라벨의 분과 실제 미루는 분이 어긋날 수 없게 상수에서 만든다.
-            snoozeButton.text = getString(R.string.alarm_snooze_action, SnoozePolicy.MINUTES)
-            snoozeButton.setOnClickListener {
-                startService(AlarmTriggerService.snoozeIntent(this))
-                finish()
-            }
-        } else {
-            // 다 쓴 뒤 눌리지 않는 버튼을 남기면 이 이슈가 그대로 되풀이된다. 아예 감춘다(#129).
-            snoozeButton.visibility = View.GONE
-        }
+        bindSnoozeButton(intent.getIntExtra(AlarmTriggerService.EXTRA_SNOOZE_COUNT, 0))
+
+        ContextCompat.registerReceiver(
+            this,
+            ringingFinishedReceiver,
+            IntentFilter(AlarmTriggerService.ACTION_RINGING_FINISHED),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val callback = OnBackInvokedCallback { }
@@ -73,6 +89,21 @@ class AlarmFullScreenActivity : Activity() {
             )
             backGestureCallback = callback
         }
+    }
+
+    /**
+     * 이 액티비티는 `singleInstance` 라 이미 떠 있으면 새 알람이 여기로 온다.
+     *
+     * 재정의하지 않으면 `intent` 가 옛 값 그대로라 화면에는 앞 알람의 제목이 남는다. 어르신은
+     * 무슨 일정인지 잘못 알게 된다(#131).
+     */
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent ?: return
+        setIntent(intent)
+        findViewById<TextView>(R.id.titleText).text = intent.getStringExtra("title") ?: "알림"
+        findViewById<TextView>(R.id.descText).text = intent.getStringExtra("desc") ?: ""
+        bindSnoozeButton(intent.getIntExtra(AlarmTriggerService.EXTRA_SNOOZE_COUNT, 0))
     }
 
     private fun updateCurrentTime(timeTextView: TextView) {
@@ -87,14 +118,43 @@ class AlarmFullScreenActivity : Activity() {
         timeHandler.post(timeRunnable)
     }
 
+    /** 다시 알림. 예약도 소리 끄기도 서비스가 한다. 화면은 시키기만 한다(#122 와 같은 자리). */
+    private fun bindSnoozeButton(snoozeCount: Int) {
+        val snoozeButton = findViewById<Button>(R.id.snoozeButton)
+        if (SnoozePolicy.canSnooze(snoozeCount)) {
+            // 라벨의 분과 실제 미루는 분이 어긋날 수 없게 상수에서 만든다.
+            snoozeButton.text = getString(R.string.alarm_snooze_action, SnoozePolicy.MINUTES)
+            snoozeButton.visibility = View.VISIBLE
+            snoozeButton.setOnClickListener {
+                startService(AlarmTriggerService.snoozeIntent(this))
+                finish()
+            }
+        } else {
+            // 다 쓴 뒤 눌리지 않는 버튼을 남기면 #129 가 그대로 되풀이된다. 아예 감춘다.
+            snoozeButton.visibility = View.GONE
+        }
+    }
+
     /** 소리와 진동은 서비스가 낸다. 여기서는 끄라고만 알린다(#122). */
     private fun dismissAlarm() {
         startService(AlarmTriggerService.dismissIntent(this))
     }
 
+    /** 화면이 안 보이면 시계를 멈춘다. 보이지 않는 화면을 1초마다 다시 그릴 이유가 없다(#131). */
+    override fun onStop() {
+        super.onStop()
+        timeHandler.removeCallbacks(timeRunnable)
+    }
+
+    override fun onRestart() {
+        super.onRestart()
+        timeHandler.post(timeRunnable)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         timeHandler.removeCallbacks(timeRunnable)
+        runCatching { unregisterReceiver(ringingFinishedReceiver) }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             backGestureCallback?.let(onBackInvokedDispatcher::unregisterOnBackInvokedCallback)
             backGestureCallback = null

--- a/core/alarm/src/main/java/com/example/slowclock/ui/alarm/AlarmTriggerService.kt
+++ b/core/alarm/src/main/java/com/example/slowclock/ui/alarm/AlarmTriggerService.kt
@@ -64,6 +64,12 @@ class AlarmTriggerService : Service() {
         // 그래서 새 id 를 쓴다(#122).
         private const val CHANNEL_ID = "alarm_ringing_v2"
 
+        /** 겹친 알람을 옮겨 두는 채널. 울리지 않고 「이 일정이 지나갔다」 만 보여 준다(#131). */
+        private const val MISSED_CHANNEL_ID = "alarm_overlapped_v1"
+
+        /** 겹친 알람의 알림 자리. 알람 자리 번호를 더해 서로 덮지 않게 한다. */
+        private const val MISSED_NOTIFICATION_ID_BASE = 1000
+
         /** 종전 채널. 오디오 속성이 없어 알람 소리로 취급되지 않았다. 남아 있으면 지운다. */
         private const val LEGACY_CHANNEL_ID = "alarm_notification_channel"
 
@@ -103,6 +109,13 @@ class AlarmTriggerService : Service() {
             Intent(context, AlarmTriggerService::class.java)
                 .setClass(context, AlarmTriggerService::class.java)
                 .setAction(ACTION_DISMISS)
+
+        /**
+         * 서비스가 알람 울리기를 끝냈다. 전체 화면이 떠 있으면 이 방송을 받아 함께 닫는다.
+         *
+         * 앱 안에서만 오가는 방송이라 패키지를 못박아 보낸다.
+         */
+        const val ACTION_RINGING_FINISHED = "com.example.slowclock.action.ALARM_RINGING_FINISHED"
 
         /** 울리는 알람을 미룬다. 다시 걸 시각과 횟수 상한은 [SnoozePolicy] 가 정한다. */
         fun snoozeIntent(context: Context): Intent =
@@ -153,6 +166,10 @@ class AlarmTriggerService : Service() {
             return START_NOT_STICKY
         }
 
+        // 이미 울리는 알람이 있으면 그 알림을 별도 자리로 옮겨 남긴다. 알림 자리가 하나뿐이라
+        // 그냥 두면 뒤에 온 알람이 앞의 것을 화면에서 지우고, 끄기 한 번에 둘 다 꺼진다(#131).
+        ringing?.let { previous -> keepAsSeparateNotification(previous) }
+
         val current =
             Ringing(
                 title = intent?.getStringExtra(EXTRA_TITLE) ?: "알람",
@@ -177,6 +194,30 @@ class AlarmTriggerService : Service() {
         stopHandler.postDelayed(stopRunnable, MAX_RINGING_MILLIS)
 
         return START_NOT_STICKY
+    }
+
+    /**
+     * 앞서 울리던 알람을 별도 알림으로 옮긴다.
+     *
+     * 포그라운드 서비스 알림 자리는 하나뿐이라, 겹친 알람을 그대로 두면 뒤에 온 것이 앞의 것을
+     * 덮어써 사용자에게는 「알람이 하나 안 울렸다」 로만 보인다. 소리와 진동은 어차피 한 벌이면
+     * 충분하므로 옮긴 알림은 조용하고, 어떤 일정이 지나갔는지 보여 주는 몫만 한다(#131).
+     */
+    private fun keepAsSeparateNotification(previous: Ringing) {
+        val notification =
+            NotificationCompat
+                .Builder(this, MISSED_CHANNEL_ID)
+                .setSmallIcon(R.drawable.baseline_access_alarm_24)
+                .setContentTitle(previous.title)
+                .setContentText(previous.desc.ifBlank { "지금 할 시간입니다" })
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setCategory(NotificationCompat.CATEGORY_ALARM)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setAutoCancel(true)
+                .build()
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        // 자리 번호로 갈라 두어야 두 알람이 서로 덮지 않는다.
+        runCatching { manager.notify(MISSED_NOTIFICATION_ID_BASE + previous.requestCode, notification) }
     }
 
     private fun startForegroundCompat(notification: Notification) {
@@ -321,12 +362,24 @@ class AlarmTriggerService : Service() {
         service.vibrate(VibrationEffect.createWaveform(VIBRATION_PATTERN, 0), attributes)
     }
 
+    /**
+     * 화면이 꺼져 있어도 소리를 이어 가도록 CPU 를 깨워 둔다.
+     *
+     * 이미 잡고 있으면 먼저 놓는다. 알람이 겹쳐 두 번째로 들어올 때 그냥 덮어쓰면 앞의 잠금은
+     * 참조를 잃어 아무도 놓지 못하고, 타임아웃까지 CPU 를 깨워 둔 채 남는다(#131).
+     */
     private fun acquireWakeLock() {
+        releaseWakeLock()
         val power = getSystemService(Context.POWER_SERVICE) as PowerManager
         wakeLock =
             power
                 .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "SlowClock:alarm")
                 .apply { acquire(MAX_RINGING_MILLIS) }
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.takeIf { it.isHeld }?.release()
+        wakeLock = null
     }
 
     /**
@@ -362,8 +415,10 @@ class AlarmTriggerService : Service() {
         stopSound()
         vibrator?.cancel()
         vibrator = null
-        wakeLock?.takeIf { it.isHeld }?.release()
-        wakeLock = null
+        releaseWakeLock()
+        // 화면이 아직 떠 있으면 함께 닫는다. 서비스가 멈춰도 액티비티는 스스로 끝나지 않아
+        // 화면이 켜진 채 남고 1초 타이머가 아침까지 돈다(#131).
+        sendBroadcast(Intent(ACTION_RINGING_FINISHED).setPackage(packageName))
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
@@ -392,6 +447,16 @@ class AlarmTriggerService : Service() {
             }
         manager.createNotificationChannel(channel)
 
+        // 겹친 알람을 옮겨 두는 자리. 소리와 진동은 울리는 쪽 한 벌이면 충분하므로 조용하다(#131).
+        manager.createNotificationChannel(
+            NotificationChannel(MISSED_CHANNEL_ID, "겹친 알람", NotificationManager.IMPORTANCE_DEFAULT).apply {
+                description = "같은 시각에 알람이 둘 이상 겹쳤을 때 남는 알림"
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                enableVibration(false)
+                setSound(null, null)
+            },
+        )
+
         // 옛 채널은 오디오 속성 없이 만들어져 알람이 아니라 알림 소리로 취급됐다. 채널은 만든 뒤
         // 고칠 수 없으므로 새 id 로 갈아탔고, 남은 것은 사용자 설정 화면에서 지운다.
         runCatching { manager.deleteNotificationChannel(LEGACY_CHANNEL_ID) }
@@ -402,7 +467,7 @@ class AlarmTriggerService : Service() {
         stopHandler.removeCallbacks(stopRunnable)
         stopSound()
         vibrator?.cancel()
-        wakeLock?.takeIf { it.isHeld }?.release()
+        releaseWakeLock()
         Log.d(TAG, "알람 서비스 종료")
     }
 


### PR DESCRIPTION
## 📌 Issues

Closes #131

## 📎 Work Description

알람이 울린 뒤가 정리되지 않았습니다. 세 가지를 고쳤습니다.

### 전체 화면이 스스로 끝나지 않았습니다

이 화면을 끝내는 `finish()` 는 닫기 버튼 하나뿐이었습니다. 서비스가 5분 뒤 스스로 멈춰도 화면은 그대로 남아, `FLAG_KEEP_SCREEN_ON` 때문에 아침까지 최대 밝기로 켜진 채 1초마다 시계를 다시 그렸습니다. 뒤로가기는 막혀 있고 최근 앱에도 없어 홈 버튼 말고는 치울 방법이 없었습니다. 새벽에 알람을 끄지 않고 다시 누우면 아침에 배터리가 바닥나 그날 다음 알람도 울리지 않습니다.

서비스가 울리기를 끝낼 때 앱 안에서만 오가는 방송을 보내고, 화면이 그것을 받아 닫습니다. 시계는 `onStop` 에서도 멈춥니다 — 보이지 않는 화면을 1초마다 다시 그릴 이유가 없습니다.

### 알람이 겹치면 앞의 것이 삼켜졌습니다

포그라운드 서비스 알림 자리가 하나뿐이라, 두 번째 알람이 같은 자리에 새 제목을 올려 앞의 것을 화면에서 지웠습니다. 끄기 한 번에 둘 다 꺼졌습니다. 「약 먹기」 를 08:00~09:00 로, 「병원 가기」 를 09:00 시작으로 넣으면 09:00 정각에 두 알람이 함께 터집니다.

앞서 울리던 알람을 별도 알림으로 옮겨 남깁니다. 자리 번호로 갈라 두어 서로 덮지 않습니다. 소리와 진동은 울리는 쪽 한 벌이면 충분하므로 옮긴 알림은 조용하고, 어떤 일정이 지나갔는지 보여 주는 몫만 합니다.

### WakeLock 이 샜습니다

`acquireWakeLock()` 이 필드를 새 잠금으로 덮어써 앞의 잠금이 참조를 잃었습니다. 아무도 놓지 못하고 5분 타임아웃까지 CPU 를 깨워 둔 채 남았습니다. 다시 잡기 전에 먼저 놓습니다.

### 겹친 알람의 제목이 화면에 반영되지 않았습니다

이 액티비티는 `singleInstance` 라 이미 떠 있으면 새 알람이 여기로 오는데 `onNewIntent` 를 재정의하지 않아 옛 제목이 그대로 남았습니다. 어르신이 무슨 일정인지 잘못 알게 됩니다. 재정의해 제목·설명과 다시 알림 버튼을 다시 그립니다.

## 📷 Screenshot

전체 화면 알람은 Compose 가 아닌 XML 레이아웃이라 스크린샷 테스트 대상이 아닙니다. baseline 변화 없습니다.

## 💬 To Reviewers

- 로컬 검증: `ktlintFormat` · `testDebugUnitTest`(전 모듈) · `:app:lintDebug` 초록입니다.
- 방송 수신기는 `ContextCompat.registerReceiver(..., RECEIVER_NOT_EXPORTED)` 로 등록하고 보낼 때 패키지를 못박습니다. 앱 밖에서 이 화면을 닫을 수 없습니다.
- 겹친 알람의 5분 타임아웃은 뒤에 온 알람 기준으로 다시 매겨집니다. 두 알람이 겹친 상황에서 늦게 온 쪽이 기준이 되는 편이 자연스러워 그대로 뒀습니다.
- 전체 화면 색·대비와 버튼 배치는 #132 에서 이어서 고칩니다.
