### PR TITLE
fix: 알람 전체 화면의 색 대비와 버튼 배치를 고령자 기준에 맞춘다 (132)

### DIFF
--- a/core/alarm/src/main/res/drawable/alarm_background.xml
+++ b/core/alarm/src/main/res/drawable/alarm_background.xml
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  색은 values/colors.xml 이 정본이다. 여기에 값을 다시 적지 않는다(#132).
+-->
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
-        android:startColor="#1A1A2E"
-        android:centerColor="#16213E"
-        android:endColor="#0F3460"
-        android:angle="45" />
+        android:angle="45"
+        android:centerColor="@color/alarm_background_center"
+        android:endColor="@color/alarm_background_end"
+        android:startColor="@color/alarm_background_start" />
 </shape>

--- a/core/alarm/src/main/res/layout/activity_alarm_fullscreen.xml
+++ b/core/alarm/src/main/res/layout/activity_alarm_fullscreen.xml
@@ -1,77 +1,85 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<?xml version="1.0" encoding="utf-8"?><!--
+  알람이 울리는 동안 잠금 화면을 덮는 화면.
+
+  버튼을 세로로 편다. 가로로 나눈 칸은 글자 크기를 키우면 반드시 잘린다 — 부모 padding 을 뺀
+  296dp 에 두 버튼이 나란히 들어가야 하는데, 글자 배율 1.5배면 그 폭을 넘어 좌우가 잘려 나갔다.
+  #107 에서 화면 밝기 선택에 같은 함정이 있었고 같은 방법으로 고쳤다(#132).
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
     android:background="@drawable/alarm_background"
-    android:padding="32dp">
-
-    <!-- 현재 시간 표시 -->
-    <TextView
-        android:id="@+id/currentTimeText"
-        android:text="00:00:00"
-        android:textSize="48sp"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="32dp"
-        android:fontFamily="monospace" />
-
-    <!-- 알람 아이콘 -->
-    <ImageView
-        android:layout_width="80dp"
-        android:layout_height="80dp"
-        android:src="@drawable/baseline_access_alarm_24"
-        android:layout_marginBottom="24dp"
-        android:tint="#FF6B6B" />
-
-    <TextView
-        android:id="@+id/titleText"
-        android:text="알람 제목"
-        android:textSize="32sp"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAlignment="center"
-        android:layout_marginBottom="16dp" />
-
-    <TextView
-        android:id="@+id/descText"
-        android:text="알람 설명"
-        android:textSize="20sp"
-        android:textColor="#E0E0E0"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAlignment="center"
-        android:layout_marginBottom="48dp" />
+    android:fillViewport="true">
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center">
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/currentTimeText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:fontFamily="monospace"
+            android:text="00:00:00"
+            android:textColor="@color/alarm_on_background"
+            android:textSize="48sp"
+            android:textStyle="bold" />
+
+        <ImageView
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:layout_marginBottom="20dp"
+            android:contentDescription="@string/alarm_icon_description"
+            android:src="@drawable/baseline_access_alarm_24"
+            android:tint="@color/alarm_icon_tint" />
+
+        <TextView
+            android:id="@+id/titleText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:text="알람 제목"
+            android:textAlignment="center"
+            android:textColor="@color/alarm_on_background"
+            android:textSize="32sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/descText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="36dp"
+            android:text="알람 설명"
+            android:textAlignment="center"
+            android:textColor="@color/alarm_on_background_variant"
+            android:textSize="20sp" />
 
         <Button
             android:id="@+id/snoozeButton"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:backgroundTint="#FFA726"
-            android:textColor="#FFFFFF"
-            android:padding="16dp" />
+            android:layout_marginBottom="16dp"
+            android:backgroundTint="@color/alarm_snooze_button"
+            android:minHeight="72dp"
+            android:padding="16dp"
+            android:textColor="@color/alarm_on_background"
+            android:textSize="22sp" />
 
         <Button
             android:id="@+id/dismissButton"
-            android:text="@string/alarm_dismiss_action"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:backgroundTint="#FF6B6B"
-            android:textColor="#FFFFFF"
-            android:padding="16dp" />
+            android:backgroundTint="@color/alarm_dismiss_button"
+            android:minHeight="72dp"
+            android:padding="16dp"
+            android:text="@string/alarm_dismiss_action"
+            android:textColor="@color/alarm_on_background"
+            android:textSize="22sp" />
 
     </LinearLayout>
 
-</LinearLayout>
+</ScrollView>

--- a/core/alarm/src/main/res/values/colors.xml
+++ b/core/alarm/src/main/res/values/colors.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  알람 전체 화면의 색. 이 화면만 XML 레이아웃이라 Compose 테마 토큰을 쓸 수 없어, 같은 값을
+  여기 한 번 더 적는다. 값은 core/ui 의 팔레트(Color.kt)에서 가져왔고 뜻도 같다 —
+  주황은 「지금 할 일」, 빨강은 「끄기」 다.
+
+  흰 글자를 얹으므로 배경색은 전부 대비 4.5:1 이상이다. 종전의 #FFA726 은 1.94:1,
+  #FF6B6B 은 2.77:1 이라 어둑한 방에서 두 버튼이 구별되지 않았다(#132).
+-->
+<resources>
+    <!-- 배경 그라데이션. 어두운 남색 계열이라 흰 글자가 15:1 이상으로 뜬다. -->
+    <color name="alarm_background_start">#FF1A1A2E</color>
+    <color name="alarm_background_center">#FF16213E</color>
+    <color name="alarm_background_end">#FF0F3460</color>
+
+    <!-- 글자. 제목은 흰색, 설명은 한 단계 낮추되 배경 대비 9:1 이상을 지킨다. -->
+    <color name="alarm_on_background">#FFFFFFFF</color>
+    <color name="alarm_on_background_variant">#FFD9E2EC</color>
+
+    <!-- 다시 알림. core/ui 의 EmberOrange(#B4460F). 흰 글자 대비 5.5:1. -->
+    <color name="alarm_snooze_button">#FFB4460F</color>
+
+    <!-- 끄기. core/ui 의 RedError(#B3261E). 흰 글자 대비 6.5:1. -->
+    <color name="alarm_dismiss_button">#FFB3261E</color>
+
+    <!-- 알람 아이콘. 배경 위에서 눈에 띄되 글자보다 앞서지 않는다. -->
+    <color name="alarm_icon_tint">#FFF3A26D</color>
+</resources>

--- a/core/alarm/src/main/res/values/strings.xml
+++ b/core/alarm/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
 <resources>
     <string name="alarm_snooze_action">다시 알림 (%1$d분)</string>
     <string name="alarm_dismiss_action">알람 끄기</string>
+    <string name="alarm_icon_description">알람</string>
 </resources>


### PR DESCRIPTION
## 📌 Issues

Closes #132

## 📎 Work Description

알람 전체 화면이 저장소에서 하드코딩 색이 남은 유일한 자리였고, 그 색들이 스스로 세운 기준을 못 지켰습니다.

### 대비

| 자리 | 배경 | 글자 | 종전 | 지금 |
|---|---|---|---|---|
| 다시 알림 | `#FFA726` → `#B4460F` | 흰색 | 1.94:1 | 5.49:1 |
| 끄기 | `#FF6B6B` → `#B3261E` | 흰색 | 2.78:1 | 6.54:1 |

`core/ui/.../theme/Color.kt` 가 「본문 대비 WCAG AA(4.5:1) 이상」 을 적어 두었는데 종전 값은 큰 글자 기준 3:1 에도 못 미쳤습니다. 어둑한 방에서 주황 버튼 위의 흰 글자와 붉은 버튼 위의 흰 글자가 구별되지 않습니다.

새 값은 `core/ui` 팔레트의 `EmberOrange`·`RedError` 를 그대로 가져왔습니다. 뜻도 같습니다 — 주황은 「지금 할 일」, 빨강은 「끄기」 입니다. 설명 글자와 배경도 9.55:1 입니다.

### 색을 한자리로

이 화면만 XML 레이아웃이라 Compose 테마 토큰을 쓸 수 없습니다. `values/colors.xml` 을 정본으로 두고 레이아웃과 배경 그라데이션이 그것을 참조합니다. 색 값이 파일 두 곳에 흩어져 있지 않습니다.

### 배치

버튼을 세로로 폈습니다. 가로로 나눈 칸은 글자 크기를 키우면 반드시 잘립니다 — 부모 padding 을 뺀 296dp 에 두 버튼이 나란히 들어가야 하는데, 글자 배율 1.5배면 그 폭을 넘어 좌우가 잘려 나갑니다. #107 에서 화면 밝기 선택에 같은 함정이 있었고 같은 방법으로 고쳤습니다.

- 두 버튼 모두 `match_parent` + 최소 높이 72dp, 글자 22sp 입니다. 종전은 기본 14sp 에 `wrap_content` 라 32sp 제목 옆에서 터치 타깃이 작았습니다.
- 바깥을 `ScrollView` 로 감쌌습니다. 제목이 길거나 글자를 아주 크게 쓰면 화면을 넘치는데, 그때 끄기 버튼에 닿지 못하면 소리와 무한 진동이 계속됩니다.
- 알람 아이콘에 `contentDescription` 을 붙였습니다.

## 📷 Screenshot

XML 레이아웃이라 스크린샷 테스트 대상이 아닙니다. baseline 변화 없습니다.

## 💬 To Reviewers

- 로컬 검증: `ktlintFormat` · `testDebugUnitTest`(전 모듈) · `:app:lintDebug` 초록입니다.
- 대비 수치는 WCAG 상대 휘도 공식으로 직접 계산한 값입니다. 표의 종전 값도 같은 방법으로 잰 것입니다.
- 이 화면이 잠금 화면 위에 뜨는 모습은 실기기에서만 확인됩니다. #122 의 기기 확인에 함께 넣습니다.
