### PR TITLE
fix: 공유 코드를 못 만들면 알리고 다시 시도할 길을 준다 (134)

### DIFF
--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/UserRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/UserRepository.kt
@@ -65,6 +65,10 @@ class UserRepository
                 publicProfilesCollection.document(userId).delete().await()
                 true
             } catch (e: Exception) {
+                // 공유 코드가 없으면 그 뒤에 만든 일정이 sharedCode 없이 저장되고, 보안 규칙의
+                // 공유 읽기 조건이 sharedCode != "" 라 가족이 어떤 코드로도 읽지 못한다.
+                // 조용히 넘기면 사용자도 보호자도 무엇이 잘못됐는지 알 방법이 없다(#134).
+                Log.e(TAG, "공유 코드 보장 실패", e)
                 false
             }
 
@@ -105,6 +109,10 @@ class UserRepository
                 }
                 true
             } catch (e: Exception) {
+                // 공유 코드가 없으면 그 뒤에 만든 일정이 sharedCode 없이 저장되고, 보안 규칙의
+                // 공유 읽기 조건이 sharedCode != "" 라 가족이 어떤 코드로도 읽지 못한다.
+                // 조용히 넘기면 사용자도 보호자도 무엇이 잘못됐는지 알 방법이 없다(#134).
+                Log.e(TAG, "공유 코드 보장 실패", e)
                 false
             }
 
@@ -156,6 +164,10 @@ class UserRepository
                 usersCollection.document(uid).update("fcmToken", token).await()
                 true
             } catch (e: Exception) {
+                // 공유 코드가 없으면 그 뒤에 만든 일정이 sharedCode 없이 저장되고, 보안 규칙의
+                // 공유 읽기 조건이 sharedCode != "" 라 가족이 어떤 코드로도 읽지 못한다.
+                // 조용히 넘기면 사용자도 보호자도 무엇이 잘못됐는지 알 방법이 없다(#134).
+                Log.e(TAG, "공유 코드 보장 실패", e)
                 false
             }
         }
@@ -168,6 +180,10 @@ class UserRepository
                 shareCodeWatcherTokens(shareCode).document(uid).set(mapOf("fcmToken" to token)).await()
                 true
             } catch (e: Exception) {
+                // 공유 코드가 없으면 그 뒤에 만든 일정이 sharedCode 없이 저장되고, 보안 규칙의
+                // 공유 읽기 조건이 sharedCode != "" 라 가족이 어떤 코드로도 읽지 못한다.
+                // 조용히 넘기면 사용자도 보호자도 무엇이 잘못됐는지 알 방법이 없다(#134).
+                Log.e(TAG, "공유 코드 보장 실패", e)
                 false
             }
         }
@@ -178,6 +194,10 @@ class UserRepository
                 shareCodeWatcherTokens(shareCode).document(uid).delete().await()
                 true
             } catch (e: Exception) {
+                // 공유 코드가 없으면 그 뒤에 만든 일정이 sharedCode 없이 저장되고, 보안 규칙의
+                // 공유 읽기 조건이 sharedCode != "" 라 가족이 어떤 코드로도 읽지 못한다.
+                // 조용히 넘기면 사용자도 보호자도 무엇이 잘못됐는지 알 방법이 없다(#134).
+                Log.e(TAG, "공유 코드 보장 실패", e)
                 false
             }
         }

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileContract.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileContract.kt
@@ -17,6 +17,9 @@ sealed interface ProfileIntent : MviIntent {
     data object ConsumeUserMessage : ProfileIntent
 
     data object ConsumeLeave : ProfileIntent
+
+    /** 공유 코드를 못 만든 상태에서 다시 시도한다. */
+    data object RetryShareCode : ProfileIntent
 }
 
 /** 화면을 떠나야 하는 이유. 로그아웃과 계정 삭제 모두 같은 경로(뒤로 가기)로 나간다. */
@@ -43,6 +46,8 @@ data class ProfileUiState(
     val isDeleting: Boolean = false,
     val userMessage: String? = null,
     val leave: ProfileLeaveReason? = null,
+    /** 공유 코드를 다시 만드는 중이다. 그동안 다시 시도 버튼을 막는다. */
+    val isRetryingShareCode: Boolean = false,
 ) : UiState
 
 /** 내 정보 화면의 상태가 겪은 것. 화면은 만들지 않고 ViewModel 만 dispatch 한다. */
@@ -54,6 +59,13 @@ sealed interface ProfileReducerEvent : ReducerEvent {
         val name: String,
         val email: String,
         val shareCode: String,
+    ) : ProfileReducerEvent
+
+    data object ShareCodeRetryStarted : ProfileReducerEvent
+
+    /** [message] 가 있으면 다시 만들지 못했다는 뜻이다. 화면이 한 번 보여 주고 소비한다. */
+    data class ShareCodeRetryFinished(
+        val message: String? = null,
     ) : ProfileReducerEvent
 
     data class LoadFailed(

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -195,11 +196,40 @@ private fun ProfileBody(
 
         Spacer(modifier = Modifier.height(4.dp))
 
-        Text(
-            text = state.shareCode.ifBlank { "-" },
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.primary,
-        )
+        if (state.shareCode.isBlank()) {
+            // 코드가 비어 있으면 그 뒤에 만든 일정은 가족이 어떤 코드로도 읽지 못한다. 비어
+            // 있다는 사실만 보여 주면 사용자가 할 수 있는 일이 없으므로 다시 시도할 길을 준다(#134).
+            Text(
+                text = "아직 만들지 못했습니다",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "코드가 없으면 가족이 내 일정을 볼 수 없습니다. 인터넷에 연결한 뒤 다시 시도해 주세요.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(
+                onClick = { onIntent(ProfileIntent.RetryShareCode) },
+                enabled = !state.isRetryingShareCode,
+                modifier = Modifier.widthIn(min = 200.dp).heightIn(min = 64.dp),
+            ) {
+                Text(
+                    text = if (state.isRetryingShareCode) "만드는 중입니다" else "공유 코드 다시 만들기",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+        } else {
+            Text(
+                text = state.shareCode,
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
 
         Spacer(modifier = Modifier.height(56.dp))
 

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileViewModel.kt
@@ -31,6 +31,7 @@ class ProfileViewModel
                 ProfileIntent.ConfirmDeleteAccount -> confirmDeleteAccount()
                 ProfileIntent.ConsumeUserMessage -> dispatch(ProfileReducerEvent.UserMessageConsumed)
                 ProfileIntent.ConsumeLeave -> dispatch(ProfileReducerEvent.LeaveConsumed)
+                ProfileIntent.RetryShareCode -> retryShareCode()
             }
         }
 
@@ -84,7 +85,46 @@ class ProfileViewModel
                 ProfileReducerEvent.LeaveConsumed -> {
                     state.copy(leave = null)
                 }
+
+                ProfileReducerEvent.ShareCodeRetryStarted -> {
+                    state.copy(isRetryingShareCode = true)
+                }
+
+                is ProfileReducerEvent.ShareCodeRetryFinished -> {
+                    state.copy(isRetryingShareCode = false, userMessage = event.message ?: state.userMessage)
+                }
             }
+
+        /**
+         * 공유 코드를 다시 만들어 본다.
+         *
+         * 신호가 약한 곳에서 처음 로그인하면 코드가 비어 있는 채로 남고, 그 뒤에 만든 일정은
+         * 가족이 어떤 코드로도 읽지 못한다. 비어 있다는 사실만 보여 주면 사용자가 할 수 있는 일이
+         * 없으므로 다시 시도할 길을 함께 둔다(#134).
+         */
+        private fun retryShareCode() {
+            if (currentState.isRetryingShareCode) return
+            val profile = authRepository.currentProfile ?: return
+            dispatch(ProfileReducerEvent.ShareCodeRetryStarted)
+            viewModelScope.launch {
+                val created =
+                    userRepository.ensureShareCode(
+                        uid = profile.uid,
+                        name = profile.displayName,
+                        email = profile.email,
+                    )
+                if (created) {
+                    dispatch(ProfileReducerEvent.ShareCodeRetryFinished())
+                    loadProfile()
+                } else {
+                    dispatch(
+                        ProfileReducerEvent.ShareCodeRetryFinished(
+                            "공유 코드를 만들지 못했습니다. 인터넷 연결을 확인한 뒤 다시 눌러 주세요.",
+                        ),
+                    )
+                }
+            }
+        }
 
         private fun loadProfile() {
             viewModelScope.launch {

--- a/feature/profile/src/test/java/com/example/slowclock/ui/profile/ProfileViewModelTest.kt
+++ b/feature/profile/src/test/java/com/example/slowclock/ui/profile/ProfileViewModelTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -157,5 +158,39 @@ class ProfileViewModelTest {
 
             assertEquals("일정을 지우지 못했습니다. 잠시 후 다시 시도해 주세요.", viewModel.uiState.value.userMessage)
             assertNull(viewModel.uiState.value.leave)
+        }
+
+    @Test
+    fun `공유 코드를 다시 만들면 화면에 반영한다`() =
+        runTest {
+            // 신호가 약한 곳에서 처음 로그인하면 코드가 비어 있는 채로 남고, 그 뒤에 만든 일정은
+            // 가족이 어떤 코드로도 읽지 못한다(#134).
+            coEvery { userRepository.getCurrentUser() } returns
+                User(id = "uid-1", name = "정일혁", email = "user@example.com", shareCode = "")
+            val viewModel = createViewModel()
+            assertEquals("", viewModel.uiState.value.shareCode)
+
+            coEvery { userRepository.ensureShareCode("uid-1", any(), any()) } returns true
+            coEvery { userRepository.getCurrentUser() } returns
+                User(id = "uid-1", name = "정일혁", email = "user@example.com", shareCode = "XYZ789")
+            viewModel.onIntent(ProfileIntent.RetryShareCode)
+
+            assertEquals("XYZ789", viewModel.uiState.value.shareCode)
+            assertFalse(viewModel.uiState.value.isRetryingShareCode)
+        }
+
+    @Test
+    fun `공유 코드를 또 못 만들면 이유를 알린다`() =
+        runTest {
+            coEvery { userRepository.getCurrentUser() } returns
+                User(id = "uid-1", name = "정일혁", email = "user@example.com", shareCode = "")
+            coEvery { userRepository.ensureShareCode(any(), any(), any()) } returns false
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(ProfileIntent.RetryShareCode)
+
+            val state = viewModel.uiState.value
+            assertNotNull(state.userMessage)
+            assertFalse(state.isRetryingShareCode)
         }
 }


### PR DESCRIPTION
## 📌 Issues

Closes #134

## 📎 Work Description

#137 에서 이 이슈의 앞 절반(구독이 다시 붙지 않는 것)을 고쳤습니다. 남은 절반입니다.

**실패를 삼키지 않습니다.** `UserRepository.ensureShareCode` 의 catch 가 예외를 통째로 삼키고 false 만 돌려줬습니다. 로그도 없었습니다. 유일한 호출자도 그 false 를 `Log.e` 한 줄로 끝냈고 화면에는 아무것도 뜨지 않았습니다. 이제 무엇 때문에 실패했는지 남깁니다.

**사용자에게 할 수 있는 일을 줍니다.** 신호가 약한 곳에서 처음 로그인하면 공유 코드가 비어 있는 채로 남습니다. 그 뒤에 만든 일정은 `sharedCode` 없이 저장되고, 보안 규칙의 공유 읽기 조건이 `sharedCode != ""` 라 가족이 어떤 코드로도 읽지 못합니다. 나중에 코드가 생겨도 이미 만든 일정은 그대로 빠진 채 남습니다.

내 정보 화면이 그 자리에 「-」 한 글자만 보여 줬습니다. 비어 있다는 사실만 보여 주면 사용자가 할 수 있는 일이 없습니다. 지금은 무엇이 안 되는지(「코드가 없으면 가족이 내 일정을 볼 수 없습니다」)와 다시 만들기 버튼을 함께 보여 줍니다. 성공하면 화면이 새 코드로 바뀌고, 또 실패하면 이유를 알립니다.

## 📷 Screenshot

`feature/profile` 에는 스크린샷 테스트가 없어 baseline 변화가 없습니다. 공유 코드가 있는 평소 화면은 그대로입니다.

## 💬 To Reviewers

- 로컬 검증: `ktlintFormat` · `testDebugUnitTest`(전 모듈) · `:app:lintDebug` 초록입니다. `ProfileViewModelTest` 10개 통과이고 그중 둘이 이번에 넣은 것입니다.
- 다시 만들기 버튼도 `heightIn(min = 64.dp)` 입니다. 이 화면의 다른 버튼과 같은 이유입니다(#135).
- 이미 `sharedCode` 가 빈 채로 저장된 일정을 뒤늦게 채우는 일은 하지 않았습니다. 그 일정을 찾아 고치려면 전체를 훑어야 하고, 코드가 생긴 뒤 만든 일정은 정상이라 v1 에서 감수할 범위로 봤습니다. 실제로 겪으면 그때 이슈로 냅니다.
