### PR TITLE
fix: 반복이 아닌 일정의 완료 표시가 되돌아가지 않게 한다 (157)

### DIFF
--- a/core/common/src/main/java/com/example/slowclock/util/ScheduleOccurrence.kt
+++ b/core/common/src/main/java/com/example/slowclock/util/ScheduleOccurrence.kt
@@ -1,0 +1,44 @@
+package com.example.slowclock.util
+
+import com.example.slowclock.data.model.Schedule
+import com.google.firebase.Timestamp
+import java.util.Date
+
+/**
+ * 일정 문서를 [dayMillis] 가 속한 날의 회차로 펼친다. 그날에 없으면 null.
+ *
+ * 반복 일정은 문서가 하나지만 날마다 다시 온다. 시작·종료 시각을 그날로 옮기고, 완료 여부는
+ * 그 회차의 것만 본다. 이 펼침이 없으면 반복 일정이 만든 날 하루만 보이고 다음 날부터 목록에서도
+ * 알람에서도 사라진다(#130).
+ *
+ * 저장소 안 private 함수가 아니라 여기 둔 이유는 검증 때문이다. Firestore 없이 이 규칙만 따로
+ * 시험할 수 없으면 「완료가 되돌아간다」 같은 회귀가 그냥 지나간다(#157).
+ */
+fun Schedule.occurrenceOn(dayMillis: Long): Schedule? {
+    val recurrence = Recurrence.of(recurring, recurringType)
+    val start =
+        RecurrenceRule.occurrenceOn(
+            baseMillis = startTime.toDate().time,
+            recurrence = recurrence,
+            dayMillis = dayMillis,
+        ) ?: return null
+
+    if (recurrence == Recurrence.NONE) {
+        // 되풀이하지 않는 일정은 문서가 곧 그 회차다. 옮길 것도, 회차를 가릴 것도 없다.
+        //
+        // 회차 식별자를 채우면 안 된다. 화면이 그 값을 완료 처리에 넘기고 저장소는 값이 있으면
+        // completedDates 를 고치는 갈래로 가는데, 읽을 때는 completed 를 보므로 쓴 곳과 읽는 곳이
+        // 어긋난다. 그러면 완료 표시가 곧바로 되돌아간다(#157).
+        return this
+    }
+
+    // 종료 시각은 시작에서 떨어진 만큼 그대로 옮긴다. 자정을 넘는 일정도 길이가 유지된다.
+    val shifted = start - startTime.toDate().time
+    val key = RecurrenceRule.occurrenceKey(start)
+    return copy(
+        startTime = Timestamp(Date(start)),
+        endTime = endTime?.let { Timestamp(Date(it.toDate().time + shifted)) },
+        completed = completedDates.contains(key),
+        occurrenceDate = key,
+    )
+}

--- a/core/common/src/test/java/com/example/slowclock/util/ScheduleOccurrenceTest.kt
+++ b/core/common/src/test/java/com/example/slowclock/util/ScheduleOccurrenceTest.kt
@@ -1,0 +1,119 @@
+package com.example.slowclock.util
+
+import com.example.slowclock.data.model.Schedule
+import com.google.firebase.Timestamp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Calendar
+import java.util.Date
+
+/**
+ * 문서를 그날의 회차로 펼치는 규칙.
+ *
+ * 저장소 안 private 함수로 두었더니 「반복이 아닌 일정의 완료가 되돌아간다」 를 놓쳤다(#157).
+ * Firestore 없이 이 규칙만 따로 시험할 수 있어야 그런 회귀가 걸린다.
+ */
+class ScheduleOccurrenceTest {
+    private fun at(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int = 9,
+    ): Long =
+        Calendar
+            .getInstance()
+            .apply {
+                set(year, month - 1, day, hour, 0, 0)
+                set(Calendar.MILLISECOND, 0)
+            }.timeInMillis
+
+    private fun schedule(
+        startMillis: Long,
+        recurring: Boolean = false,
+        recurringType: String? = null,
+        completed: Boolean = false,
+        completedDates: List<String> = emptyList(),
+        endMillis: Long? = null,
+    ) = Schedule(
+        id = "doc-1",
+        title = "약 먹기",
+        startTime = Timestamp(Date(startMillis)),
+        endTime = endMillis?.let { Timestamp(Date(it)) },
+        completed = completed,
+        recurring = recurring,
+        recurringType = recurringType,
+        completedDates = completedDates,
+    )
+
+    @Test
+    fun `반복이 아닌 일정은 회차 식별자를 갖지 않는다`() {
+        // 채우면 화면이 그 값을 완료 처리에 넘기고 저장소가 completedDates 를 고치는 갈래로 간다.
+        // 읽을 때는 completed 를 보므로 완료 표시가 곧바로 되돌아간다(#157).
+        val base = at(2026, 9, 6)
+
+        val occurrence = schedule(base).occurrenceOn(at(2026, 9, 6, hour = 20))
+
+        assertEquals("", occurrence?.occurrenceDate)
+    }
+
+    @Test
+    fun `반복이 아닌 일정은 문서의 완료 여부를 그대로 쓴다`() {
+        val base = at(2026, 9, 6)
+
+        val occurrence = schedule(base, completed = true).occurrenceOn(at(2026, 9, 6, hour = 20))
+
+        assertTrue(occurrence!!.completed)
+    }
+
+    @Test
+    fun `반복이 아닌 일정은 그날에만 나온다`() {
+        val base = at(2026, 9, 6)
+
+        assertNull(schedule(base).occurrenceOn(at(2026, 9, 7)))
+    }
+
+    @Test
+    fun `반복 일정은 회차 식별자를 갖는다`() {
+        val base = at(2026, 9, 6)
+
+        val occurrence =
+            schedule(base, recurring = true, recurringType = "daily")
+                .occurrenceOn(at(2026, 9, 8, hour = 0))
+
+        assertEquals("2026-09-08", occurrence?.occurrenceDate)
+        assertEquals(at(2026, 9, 8), occurrence?.startTime?.toDate()?.time)
+    }
+
+    @Test
+    fun `반복 일정의 완료는 그 회차의 것만 본다`() {
+        val base = at(2026, 9, 6)
+        val daily = schedule(base, recurring = true, recurringType = "daily", completedDates = listOf("2026-09-06"))
+
+        assertTrue(daily.occurrenceOn(at(2026, 9, 6, hour = 20))!!.completed)
+        assertFalse(daily.occurrenceOn(at(2026, 9, 7, hour = 20))!!.completed)
+    }
+
+    @Test
+    fun `반복 일정의 completed 필드는 회차 판정에 쓰이지 않는다`() {
+        // 문서에 하나뿐인 completed 를 반복 일정에 쓰면 한 번 완료한 뒤 영영 완료로 남는다.
+        val base = at(2026, 9, 6)
+        val daily = schedule(base, recurring = true, recurringType = "daily", completed = true)
+
+        assertFalse(daily.occurrenceOn(at(2026, 9, 7, hour = 20))!!.completed)
+    }
+
+    @Test
+    fun `종료 시각은 시작에서 떨어진 만큼 함께 옮긴다`() {
+        val base = at(2026, 9, 6, hour = 22)
+        val end = at(2026, 9, 7, hour = 1) // 자정을 넘긴다
+        val daily = schedule(base, recurring = true, recurringType = "daily", endMillis = end)
+
+        val occurrence = daily.occurrenceOn(at(2026, 9, 8, hour = 12))!!
+
+        assertEquals(at(2026, 9, 8, hour = 22), occurrence.startTime.toDate().time)
+        assertEquals(at(2026, 9, 9, hour = 1), occurrence.endTime!!.toDate().time)
+    }
+}

--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt
@@ -5,8 +5,7 @@ import android.util.Log
 import com.example.slowclock.data.FirestoreCollections
 import com.example.slowclock.data.model.Schedule
 import com.example.slowclock.util.AppError
-import com.example.slowclock.util.Recurrence
-import com.example.slowclock.util.RecurrenceRule
+import com.example.slowclock.util.occurrenceOn
 import com.example.slowclock.util.toAppError
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
@@ -121,32 +120,6 @@ class ScheduleRepository
                 Log.e("ScheduleRepo", "일정 파싱 실패: ${doc.id}", e)
                 null
             }
-        }
-
-        /**
-         * 문서 하나를 [dayMillis] 가 속한 날의 회차로 펼친다. 그날에 없으면 null.
-         *
-         * 반복 일정은 문서가 하나지만 날마다 다시 온다. 시작·종료 시각을 그날로 옮기고, 완료
-         * 여부는 그 회차의 것만 본다. 이 펼침이 없으면 반복 일정이 만든 날 하루만 보이고
-         * 다음 날부터 목록에서도 알람에서도 사라진다(#130).
-         */
-        private fun Schedule.occurrenceOn(dayMillis: Long): Schedule? {
-            val recurrence = Recurrence.of(recurring, recurringType)
-            val start =
-                RecurrenceRule.occurrenceOn(
-                    baseMillis = startTime.toDate().time,
-                    recurrence = recurrence,
-                    dayMillis = dayMillis,
-                ) ?: return null
-            val key = RecurrenceRule.occurrenceKey(start)
-            // 종료 시각은 시작에서 떨어진 만큼 그대로 옮긴다. 자정을 넘는 일정도 길이가 유지된다.
-            val shifted = start - startTime.toDate().time
-            return copy(
-                startTime = Timestamp(Date(start)),
-                endTime = endTime?.let { Timestamp(Date(it.toDate().time + shifted)) },
-                completed = if (recurrence == Recurrence.NONE) completed else completedDates.contains(key),
-                occurrenceDate = key,
-            )
         }
 
         // 특정 날짜의 data 가져오기


### PR DESCRIPTION
## 📌 Issues

Closes #157

## 📎 Work Description

#130 에서 들어간 회귀입니다. 반복이 아닌 일반 일정을 완료로 표시해도 곧 되돌아갔습니다.

회차 펼침이 `occurrenceDate` 를 **모든 일정에** 채웠습니다. 화면은 그 값을 완료 처리에 넘기고, 저장소는 값이 비어 있지 않으면 `completed` 대신 `completedDates` 를 고치는 갈래로 갑니다. 그런데 읽을 때는 반복이 아닌 일정의 완료 여부를 `completed` 에서 읽습니다. 쓴 곳과 읽는 곳이 어긋났습니다.

화면에서는 이렇게 보입니다. 「다 했어요」 를 누르면 낙관적 갱신으로 잠깐 완료가 되고, Firestore 리스너가 문서를 다시 내는 순간 되돌아갑니다. 몇 번을 눌러도 같습니다. 이 앱에서 가장 많이 눌리는 버튼이고 반복을 쓰지 않는 사용자 전부가 겪습니다.

**회차 식별자는 되풀이하는 일정에만 채웁니다.** 되풀이하지 않는 일정은 문서가 곧 그 회차라 옮길 것도 회차를 가릴 것도 없으므로 문서를 그대로 돌려줍니다.

**펼침을 `core/common` 으로 옮겼습니다.** 저장소 안 private 함수라 Firestore 없이 이 규칙만 따로 시험할 수 없었고, 그래서 이 회귀가 그냥 지나갔습니다. 이제 순수 함수이고 단위 테스트 7개가 붙습니다.

- 반복이 아닌 일정은 회차 식별자를 갖지 않는다 ← 이 회귀를 잡는 테스트
- 반복이 아닌 일정은 문서의 완료 여부를 그대로 쓴다
- 반복이 아닌 일정은 그날에만 나온다
- 반복 일정은 회차 식별자를 갖고 시작 시각이 그날로 옮겨진다
- 반복 일정의 완료는 그 회차의 것만 본다
- 반복 일정의 `completed` 필드는 회차 판정에 쓰이지 않는다
- 종료 시각은 시작에서 떨어진 만큼 함께 옮긴다(자정을 넘겨도)

## 📷 Screenshot

화면 코드는 바뀌지 않았습니다. baseline 그대로입니다.

## 💬 To Reviewers

- 로컬 검증: `ktlintFormat` · `testDebugUnitTest`(전 모듈 110개 통과) · `:app:lintDebug` 초록입니다.
- #130 을 머지한 직후 스스로 다시 읽다가 찾았습니다. 기기 확인 전에 걸린 것이 다행입니다.
