### PR TITLE
fix: 이슈 번호로 시작하는 줄이 릴리스 노트 섹션을 끊지 않게 한다 (159)

### DIFF
--- a/.github/scripts/render-distribution-release-notes.sh
+++ b/.github/scripts/render-distribution-release-notes.sh
@@ -20,8 +20,11 @@ extract_section() {
     local ascii_marker="$2"
     local body_file="$3"
 
+    # 제목은 「# 뒤에 공백」 이 있는 줄뿐이다(마크다운 ATX). 이 구분이 없으면 「#130 에서 …」 처럼
+    # 이슈 번호로 시작하는 본문 줄이 제목으로 읽혀 섹션이 거기서 끊긴다. 그러면 Work Description
+    # 이 비어 배포가 「변경 내용이 하나 이상 필요합니다」 로 막힌다(#159).
     awk -v marker="$marker" -v ascii_marker="$ascii_marker" '
-        /^#[#]*[[:space:]]*/ {
+        /^#+[[:space:]]/ {
             heading = $0
             if (capturing) {
                 exit
@@ -102,7 +105,11 @@ normalized_notes="$(
 
             {
                 point = $0
-                sub(/^[[:space:]]*[-*][[:space:]]*/, "", point)
+                # 목록 표시는 「- 」 나 「* 」 처럼 뒤에 공백이 온다. 공백을 요구하지 않으면
+                # 「**굵게** 로 시작하는 문단」 의 별표 하나를 목록 표시로 보고 잘라 낸다(#159).
+                sub(/^[[:space:]]*[-*][[:space:]]+/, "", point)
+                # 내용 없이 표시만 있는 줄. 이 줄은 비운 것으로 봐야 아래 검사가 걸러 낸다.
+                sub(/^[[:space:]]*[-*][[:space:]]*$/, "", point)
                 sub(/^[[:space:]]*[0-9]+\.[[:space:]]*/, "", point)
                 sub(/^[[:space:]]+/, "", point)
                 sub(/[[:space:]]+$/, "", point)

--- a/.github/scripts/render-distribution-release-notes.test.mjs
+++ b/.github/scripts/render-distribution-release-notes.test.mjs
@@ -113,3 +113,42 @@ test("수동 실행(WIF canary)은 입력값을 ; 로 나눠 릴리스 노트로
     assert.match(notes, /^SlowClock 수동 배포 \(WIF canary\)\n/);
     assert.match(notes, /포함 이슈\n- #35\n\n변경 내용\n- WIF 인증 업로드 확인\n- 앱이 로그인 화면까지 뜬다\n$/);
 });
+
+test("이슈 번호로 시작하는 본문 줄이 섹션을 끊지 않는다", async (t) => {
+    // 마크다운에서 # 뒤에 공백이 없으면 제목이 아니다. 구분하지 않으면 「#130 에서 …」 처럼
+    // 이슈 번호로 문장을 시작한 PR 이 그 줄에서 섹션을 끊어 배포가 막힌다(#159 실측).
+    const body =
+        "## 📌 Issues\n\nCloses #157\n\n## 📎 Work Description\n\n" +
+        "#130 에서 들어간 회귀입니다.\n- 회차 식별자를 되풀이하는 일정에만 채운다\n\n" +
+        "## 📷 Screenshot\n\n없음\n";
+    const { result, outputPath } = await runRenderer(t, { eventName: "push", body });
+    const notes = await fs.readFile(outputPath, "utf8");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(notes, /#130 에서 들어간 회귀입니다\./);
+    assert.match(notes, /회차 식별자를 되풀이하는 일정에만 채운다/);
+});
+
+test("섹션은 다음 제목에서 끊긴다", async (t) => {
+    // 위 완화가 섹션 경계까지 풀어 버리면 Screenshot 문단이 변경 내용으로 섞여 들어간다.
+    const body =
+        "## 📌 Issues\n\nCloses #7\n\n## 📎 Work Description\n\n" +
+        "- 알람이 잠금 화면에서도 뜬다\n\n## 📷 Screenshot\n\n스크린샷 없음\n";
+    const { result, outputPath } = await runRenderer(t, { eventName: "push", body });
+    const notes = await fs.readFile(outputPath, "utf8");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(notes, /알람이 잠금 화면에서도 뜬다/);
+    assert.doesNotMatch(notes, /스크린샷 없음/);
+});
+
+test("굵은 글씨로 시작하는 문단의 별표를 잘라 내지 않는다", async (t) => {
+    const body =
+        "## 📌 Issues\n\nCloses #8\n\n## 📎 Work Description\n\n" +
+        "**회차 식별자는 되풀이하는 일정에만 채웁니다.** 나머지는 그대로다.\n";
+    const { result, outputPath } = await runRenderer(t, { eventName: "push", body });
+    const notes = await fs.readFile(outputPath, "utf8");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(notes, /\*\*회차 식별자는 되풀이하는 일정에만 채웁니다\.\*\*/);
+});


### PR DESCRIPTION
## 📌 Issues

Closes #159

## 📎 Work Description

테스터 배포가 막혀 있었습니다. 회귀 수정(#157)을 머지했는데 그 빌드가 테스터에게 나가지 못했고, 지금 테스터가 가진 최신 빌드에는 그 회귀가 그대로 남아 있습니다.

```
run 34010937344 (main @ c7db4eb)
  실패 스텝: Prepare Firebase release notes
  ##[error]Work Description 섹션에는 변경 내용이 하나 이상 필요합니다.
```

**원인은 제목 판정입니다.** `extract_section` 이 `^#` 로 시작하는 줄을 전부 제목으로 봤습니다. 그런데 마크다운에서 `#` 뒤에 공백이 없으면 제목이 아닙니다. 「#130 에서 들어간 회귀입니다」 는 본문 한 줄인데 생성기가 제목으로 읽고 섹션을 거기서 끊었고, Work Description 이 비어 실패했습니다.

이슈 번호로 문장을 시작하는 것은 이 저장소에서 자연스러운 문체라 다음에도 같은 자리에서 걸립니다. `#` 뒤에 공백이 오는 줄만 제목으로 봅니다(ATX 정의와 같습니다).

**같은 자리에서 하나 더 나왔습니다.** 목록 표시를 벗기는 `sub` 가 뒤따르는 공백을 요구하지 않아, `**굵게**` 로 시작하는 문단의 별표 하나를 잘라 냈습니다. 실제로 나간 노트에 `- *회차 식별자는 …` 처럼 별표가 하나 남아 있었습니다. 목록 표시는 뒤에 공백이 오는 것만으로 한정하고, 내용 없이 표시만 있는 줄은 따로 비웁니다(그 줄을 아래 검사가 걸러야 하므로).

## 📷 Screenshot

배포 도구 변경입니다. 앱 화면은 그대로입니다.

## 💬 To Reviewers

- 회귀 테스트 3개를 넣었습니다. 이슈 번호로 시작하는 줄이 섹션을 끊지 않는지, 그럼에도 섹션이 다음 제목에서는 끊기는지(완화가 경계까지 풀지 않았는지), 굵은 글씨의 별표가 남는지.
- `node --test .github/scripts/*.test.mjs` 249개 전부 통과합니다.
- 고치기 전과 후를 실제 PR #158 본문으로 나란히 돌려 확인했습니다. 고치기 전에는 실패, 후에는 통과하고 노트에 변경 내용이 들어갑니다.
- 이 PR 이 머지되면 그 push 로 배포가 다시 돌아 테스터가 #157 수정본을 받습니다. 머지 뒤 실제로 나갔는지 확인하겠습니다.
