### PR TITLE
fix: 로그아웃할 때 이 기기에 남는 알람과 공유 코드를 함께 지운다 (165)

### DIFF
--- a/app/src/main/java/com/example/slowclock/MainActivity.kt
+++ b/app/src/main/java/com/example/slowclock/MainActivity.kt
@@ -23,6 +23,7 @@ import com.example.slowclock.data.model.ThemeMode
 import com.example.slowclock.data.remote.repository.AuthRepository
 import com.example.slowclock.data.remote.repository.SettingsRepository
 import com.example.slowclock.data.remote.repository.UserRepository
+import com.example.slowclock.domain.profile.SignOutUseCase
 import com.example.slowclock.navigation.AppNavigation
 import com.example.slowclock.ui.theme.SlowClockTheme
 import com.firebase.ui.auth.AuthUI
@@ -43,6 +44,9 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var settingsRepository: SettingsRepository
 
+    @Inject
+    lateinit var signOutUseCase: SignOutUseCase
+
     private fun handleNewInstallation() {
         val prefs = getSharedPreferences("app_state", MODE_PRIVATE)
         val isAppEverLaunched = prefs.getBoolean("app_launched", false)
@@ -51,7 +55,9 @@ class MainActivity : ComponentActivity() {
             // 이 앱이 처음 실행됨 = 새 설치
             Log.d("INSTALL", "새 설치 감지 - Firebase 로그아웃")
 
-            authRepository.signOut()
+            // 앱을 지웠다 다시 깐 기기다. 세션뿐 아니라 앞 설치가 남긴 알람 장부와 공유 코드도
+            // 함께 비운다. 남기면 목록에 없는 알람이 계속 울린다(#165).
+            signOutUseCase()
             AuthUI.getInstance().signOut(this)
 
             // 플래그 저장

--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/SettingsRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/SettingsRepository.kt
@@ -29,6 +29,16 @@ class SettingsRepository
             prefs.edit().putString(KEY_SHARE_CODE, shareCode.trim()).apply()
         }
 
+        /**
+         * 등록해 둔 가족의 공유 코드를 지운다. 세션이 끝날 때 부른다.
+         *
+         * 남겨 두면 같은 기기에 다른 사람이 로그인했을 때 앞 사람이 등록한 가족의 일정이
+         * 그대로 보인다. 어르신 폰을 자녀가 잠깐 쓰는 일이 이 앱에서는 드물지 않다(#165).
+         */
+        fun clearShareCode() {
+            prefs.edit().remove(KEY_SHARE_CODE).apply()
+        }
+
         fun getThemeMode(): ThemeMode = ThemeMode.fromName(prefs.getString(KEY_THEME_MODE, null))
 
         fun setThemeMode(mode: ThemeMode) {

--- a/feature/profile/src/main/java/com/example/slowclock/domain/profile/SignOutUseCase.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/domain/profile/SignOutUseCase.kt
@@ -1,0 +1,35 @@
+package com.example.slowclock.domain.profile
+
+import com.example.slowclock.core.alarm.AlarmScheduler
+import com.example.slowclock.data.remote.repository.AuthRepository
+import com.example.slowclock.data.remote.repository.SettingsRepository
+import javax.inject.Inject
+
+/**
+ * 로그아웃. 세션을 끊는 것으로 끝나지 않고 이 기기에 남는 그 사람의 흔적을 함께 지운다.
+ *
+ * 알람은 기기 안 장부로 살아 있고 로그인 여부를 보지 않는다. 반복 일정은 회차가 무한히
+ * 이어지고(#130) 재부팅에도 살아남으므로(#127), 지우지 않으면 로그아웃한 계정의 알람이 그
+ * 기기에서 영구히 매일 울린다. 목록에는 없으니 사용자가 끌 방법도 없다(#165).
+ *
+ * 등록해 둔 가족의 공유 코드도 지운다. 남겨 두면 같은 기기에 다른 사람이 로그인했을 때 앞
+ * 사람이 등록한 가족의 일정이 그대로 보인다.
+ *
+ * 여러 Repository 를 순서대로 조합하고 두 화면이 함께 쓰므로 UseCase 로 둔다. 계정 삭제가
+ * 이미 같은 짝을 [DeleteAccountUseCase] 에서 맞추고 있어 자리도 같다.
+ */
+class SignOutUseCase
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val alarmScheduler: AlarmScheduler,
+        private val settingsRepository: SettingsRepository,
+    ) {
+        operator fun invoke() {
+            // 세션을 끊기 전에 기기 잔재부터 지운다. 순서가 반대면 중간에 실패했을 때
+            // 로그인은 풀렸는데 알람만 남는 상태가 된다.
+            alarmScheduler.cancelAll()
+            settingsRepository.clearShareCode()
+            authRepository.signOut()
+        }
+    }

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileViewModel.kt
@@ -6,6 +6,7 @@ import com.example.slowclock.data.remote.repository.UserRepository
 import com.example.slowclock.domain.profile.DeleteAccountResult
 import com.example.slowclock.domain.profile.DeleteAccountStep
 import com.example.slowclock.domain.profile.DeleteAccountUseCase
+import com.example.slowclock.domain.profile.SignOutUseCase
 import com.example.slowclock.ui.mvi.MviViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -18,6 +19,7 @@ class ProfileViewModel
         private val userRepository: UserRepository,
         private val authRepository: AuthRepository,
         private val deleteAccount: DeleteAccountUseCase,
+        private val signOutUseCase: SignOutUseCase,
     ) : MviViewModel<ProfileIntent, ProfileUiState, ProfileReducerEvent>(ProfileUiState()) {
         init {
             loadProfile()
@@ -145,7 +147,8 @@ class ProfileViewModel
         }
 
         private fun signOut() {
-            authRepository.signOut()
+            // 세션만 끊으면 이 기기에 걸린 알람과 등록해 둔 공유 코드가 남는다(#165).
+            signOutUseCase()
             dispatch(ProfileReducerEvent.Left(ProfileLeaveReason.SIGNED_OUT))
         }
 

--- a/feature/profile/src/test/java/com/example/slowclock/domain/profile/SignOutUseCaseTest.kt
+++ b/feature/profile/src/test/java/com/example/slowclock/domain/profile/SignOutUseCaseTest.kt
@@ -1,0 +1,34 @@
+package com.example.slowclock.domain.profile
+
+import com.example.slowclock.core.alarm.AlarmScheduler
+import com.example.slowclock.data.remote.repository.AuthRepository
+import com.example.slowclock.data.remote.repository.SettingsRepository
+import io.mockk.mockk
+import io.mockk.verifyOrder
+import org.junit.Test
+
+/**
+ * 로그아웃이 기기에 남는 흔적을 함께 지우는지 본다.
+ *
+ * 지우지 않으면 로그아웃한 계정의 반복 알람이 그 기기에서 영구히 매일 울린다. 목록에는 없으니
+ * 사용자가 끌 방법도 없다(#165).
+ */
+class SignOutUseCaseTest {
+    private val authRepository = mockk<AuthRepository>(relaxed = true)
+    private val alarmScheduler = mockk<AlarmScheduler>(relaxed = true)
+    private val settingsRepository = mockk<SettingsRepository>(relaxed = true)
+
+    private val signOut = SignOutUseCase(authRepository, alarmScheduler, settingsRepository)
+
+    @Test
+    fun `세션을 끊기 전에 기기 잔재를 먼저 지운다`() {
+        // 순서가 반대면 중간에 실패했을 때 로그인은 풀렸는데 알람만 남는다.
+        signOut()
+
+        verifyOrder {
+            alarmScheduler.cancelAll()
+            settingsRepository.clearShareCode()
+            authRepository.signOut()
+        }
+    }
+}

--- a/feature/profile/src/test/java/com/example/slowclock/ui/profile/ProfileViewModelTest.kt
+++ b/feature/profile/src/test/java/com/example/slowclock/ui/profile/ProfileViewModelTest.kt
@@ -6,6 +6,7 @@ import com.example.slowclock.data.remote.repository.UserRepository
 import com.example.slowclock.domain.profile.DeleteAccountResult
 import com.example.slowclock.domain.profile.DeleteAccountStep
 import com.example.slowclock.domain.profile.DeleteAccountUseCase
+import com.example.slowclock.domain.profile.SignOutUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -35,6 +36,7 @@ class ProfileViewModelTest {
     private val userRepository = mockk<UserRepository>()
     private val authRepository = mockk<AuthRepository>()
     private val deleteAccount = mockk<DeleteAccountUseCase>()
+    private val signOutUseCase = mockk<SignOutUseCase>(relaxed = true)
 
     @Before
     fun setUp() {
@@ -51,7 +53,7 @@ class ProfileViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = ProfileViewModel(userRepository, authRepository, deleteAccount)
+    private fun createViewModel() = ProfileViewModel(userRepository, authRepository, deleteAccount, signOutUseCase)
 
     @Test
     fun `Firestore 사용자 문서로 이름·이메일·공유 코드를 채운다`() =
@@ -94,7 +96,7 @@ class ProfileViewModelTest {
 
             viewModel.onIntent(ProfileIntent.SignOut)
 
-            verify(exactly = 1) { authRepository.signOut() }
+            verify(exactly = 1) { signOutUseCase() }
             assertEquals(ProfileLeaveReason.SIGNED_OUT, viewModel.uiState.value.leave)
 
             viewModel.onIntent(ProfileIntent.ConsumeLeave)


### PR DESCRIPTION
## 📌 Issues

Closes #165

## 📎 Work Description

로그아웃해도 그 계정의 알람이 기기에 그대로 남았습니다. 반복 일정이면 매일 영구히 울리고, 목록에 없어 끌 방법이 없습니다.

어제까지는 이 자리가 큰 문제가 아니었습니다. 걸어 둔 알람이 한 번 울리고 끝났고 재부팅하면 사라졌기 때문입니다. 그런데 같은 세션에서 두 가지가 바뀌었습니다.

- #130 으로 회차가 무한히 이어집니다.
- #127 로 재부팅에도 살아남습니다.

그래서 지금은 로그아웃한 계정의 반복 알람이 그 기기에서 영구히 울립니다. 부모님 폰에서 자녀 계정으로 시험 삼아 일정을 하나 저장하고 로그아웃하면, 목록에 없는 알람이 매일 뜨고 벗어나는 길은 앱 데이터 삭제뿐입니다.

**세션을 끝내는 일을 한 자리로 모았습니다.** 로그아웃은 두 곳에서 일어납니다 — 내 정보 화면과, 앱을 지웠다 다시 깐 것을 감지하는 `MainActivity` 입니다. 둘이 각자 `authRepository.signOut()` 만 부르고 있었습니다. `SignOutUseCase` 가 셋을 순서대로 합니다.

1. `alarmScheduler.cancelAll()` — 걸린 알람과 기기 안 장부를 비웁니다.
2. `settingsRepository.clearShareCode()` — 등록해 둔 가족의 공유 코드를 지웁니다.
3. `authRepository.signOut()` — 세션을 끊습니다.

순서가 중요합니다. 세션을 먼저 끊으면 중간에 실패했을 때 로그인은 풀렸는데 알람만 남는 상태가 됩니다. 테스트가 그 순서를 못 박습니다.

**공유 코드를 지우는 쪽을 골랐습니다.** #137 에서 미뤄 둔 판단입니다. 남겨 두면 같은 기기에 다른 사람이 로그인했을 때 앞 사람이 등록한 가족의 일정이 그대로 보입니다. 어르신 폰을 자녀가 잠깐 쓰는 일이 이 앱에서는 드물지 않아, 다시 입력하는 번거로움보다 남의 일정이 보이는 쪽이 나쁘다고 봤습니다.

여러 Repository 를 순서대로 조합하고 두 화면이 함께 쓰므로 UseCase 로 뒀습니다. 계정 삭제가 이미 같은 짝을 `DeleteAccountUseCase` 에서 맞추고 있어 자리도 같습니다.

## 📷 Screenshot

화면 변경 없습니다.

## 💬 To Reviewers

- 로컬 검증: `ktlintFormat` · `testDebugUnitTest`(전 모듈 111개 통과) · `:app:lintDebug` 초록입니다.
- 가족 공유 코드에 걸어 둔 감시자 등록(`shareCodeWatchers`)은 이 PR 에서 지우지 않습니다. 계정 삭제 경로는 지우지만, 로그아웃은 다시 돌아올 수 있는 상태이고 그 등록으로 나가는 푸시 자체가 #102 로 막혀 있습니다. 로그아웃 중 네트워크 호출을 하나 더 늘리는 값이 지금은 없다고 봤습니다.
- 실기기 확인 항목에 「로그아웃 뒤 앞 계정의 알람이 울리지 않는가」 를 더합니다. #122 의 목록에 함께 적어 두겠습니다.
