### PR TITLE
fix: 공유 코드를 만들 때 코드 없이 저장된 일정도 함께 맞춘다 (178)

### DIFF
--- a/app/src/main/java/com/example/slowclock/MainActivity.kt
+++ b/app/src/main/java/com/example/slowclock/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.lifecycleScope
 import com.example.slowclock.auth.AuthManager
 import com.example.slowclock.data.model.ThemeMode
 import com.example.slowclock.data.remote.repository.AuthRepository
+import com.example.slowclock.data.remote.repository.ScheduleRepository
 import com.example.slowclock.data.remote.repository.SettingsRepository
 import com.example.slowclock.data.remote.repository.UserRepository
 import com.example.slowclock.domain.profile.SignOutUseCase
@@ -37,6 +38,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var userRepository: UserRepository
+
+    @Inject
+    lateinit var scheduleRepository: ScheduleRepository
 
     @Inject
     lateinit var authRepository: AuthRepository
@@ -73,7 +77,7 @@ class MainActivity : ComponentActivity() {
 
         try {
             // AuthManager 초기화
-            authManager = AuthManager(this, userRepository, authRepository)
+            authManager = AuthManager(this, userRepository, authRepository, scheduleRepository)
             authManager.initialize(
                 onSuccess = {
                     Log.d("AUTH", "로그인 성공 콜백")

--- a/app/src/main/java/com/example/slowclock/auth/AuthManager.kt
+++ b/app/src/main/java/com/example/slowclock/auth/AuthManager.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
 import com.example.slowclock.data.remote.repository.AuthRepository
+import com.example.slowclock.data.remote.repository.ScheduleRepository
 import com.example.slowclock.data.remote.repository.UserRepository
 import com.firebase.ui.auth.AuthUI
 import com.firebase.ui.auth.IdpResponse
@@ -21,6 +22,7 @@ class AuthManager(
     private val activity: ComponentActivity,
     private val userRepository: UserRepository,
     private val authRepository: AuthRepository,
+    private val scheduleRepository: ScheduleRepository,
 ) {
     private companion object {
         // GitHub Pages(docs/) 에 게시된 문서. Play 콘솔의 개인정보처리방침 URL 과 같은 주소를 쓴다.
@@ -53,14 +55,21 @@ class AuthManager(
             }
     }
 
-    /** 사용자 문서와 공유 코드를 보장한다. 이름·이메일이 바뀌었으면 함께 맞춘다. */
+    /**
+     * 사용자 문서와 공유 코드를 보장한다. 이름·이메일이 바뀌었으면 함께 맞춘다.
+     *
+     * 코드를 얻은 뒤에는 코드 없이 저장돼 있던 일정에도 채운다. 코드만 만들면 그 전에 만든
+     * 일정은 가족이 영영 못 읽는다(#178).
+     */
     fun ensureShareCodeForUser(
         uid: String,
         name: String,
         email: String,
     ) {
         activity.lifecycleScope.launch {
-            if (!userRepository.ensureShareCode(uid, name, email)) {
+            if (userRepository.ensureShareCode(uid, name, email)) {
+                scheduleRepository.fillMissingSharedCode(uid)
+            } else {
                 Log.e("AUTH", "공유 코드 생성/저장 실패")
             }
         }

--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt
@@ -470,6 +470,52 @@ class ScheduleRepository
             }
         }
 
+        /**
+         * 공유 코드 없이 저장된 내 일정에 코드를 채운다. 채운 건수를 낸다.
+         *
+         * 일정은 저장할 때의 공유 코드를 문서에 굳혀 넣는다. 신호가 약한 곳에서 처음 로그인하면
+         * 코드가 비어 있고, 그 사이에 만든 일정은 `sharedCode` 가 빈 채로 남는다. 보안 규칙의
+         * 공유 읽기가 `sharedCode != ""` 를 요구하므로, 나중에 코드를 만들어도 그 일정들은
+         * 가족이 어떤 코드로도 읽지 못한다.
+         *
+         * 사용자 쪽에서는 코드를 만들어 가족에게 알려 줬는데 일정이 안 보인다. 화면 어디에도
+         * 이유가 없고 되돌릴 길도 없다 — 「공유 코드 다시 만들기」(#134)는 사용자 문서만 고쳤다.
+         * 그래서 코드를 보장하는 자리에서 이미 저장된 일정도 함께 맞춘다(#178).
+         *
+         * 실패해도 던지지 않는다. 코드를 만든 결과를 이 일이 뒤집으면 안 되고, 다음 로그인에서
+         * 다시 맞추면 된다.
+         */
+        suspend fun fillMissingSharedCode(userId: String): Int =
+            try {
+                val shareCode = fetchShareCode(userId)
+                if (shareCode.isBlank()) {
+                    0
+                } else {
+                    val stale =
+                        schedulesCollection
+                            .whereEqualTo("userId", userId)
+                            .whereEqualTo("sharedCode", "")
+                            .get()
+                            .await()
+                            .documents
+                    stale.chunked(FirestoreCollections.BATCH_LIMIT).forEach { chunk ->
+                        val batch = firestore.batch()
+                        chunk.forEach { document ->
+                            batch.update(
+                                document.reference,
+                                mapOf("sharedCode" to shareCode, "updatedAt" to Timestamp.now()),
+                            )
+                        }
+                        batch.commit().await()
+                    }
+                    if (stale.isNotEmpty()) Log.d("ScheduleRepo", "공유 코드를 채운 일정: ${stale.size}건")
+                    stale.size
+                }
+            } catch (e: Exception) {
+                Log.e("ScheduleRepo", "빠진 공유 코드 채우기 실패", e)
+                0
+            }
+
         // 계정 삭제용: 사용자가 만든 일정 전부 삭제
         suspend fun deleteAllSchedulesOf(userId: String): Boolean =
             try {

--- a/core/data/src/test/java/com/example/slowclock/data/remote/repository/ScheduleRepositoryAddScheduleTest.kt
+++ b/core/data/src/test/java/com/example/slowclock/data/remote/repository/ScheduleRepositoryAddScheduleTest.kt
@@ -10,8 +10,12 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.WriteBatch
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -80,6 +84,86 @@ class ScheduleRepositoryAddScheduleTest {
                 AppError.NetworkError,
                 (result as ScheduleRepository.ScheduleResult.Error).error,
             )
+        }
+
+    /**
+     * 공유 코드 없이 저장된 일정을 찾아 채우는 경로를 세운다.
+     *
+     * [shareCode] 를 사용자 문서가 낸다고 보고, 빈 코드로 저장된 일정 [staleCount] 건이
+     * 걸린다고 둔다. 반환하는 batch 로 실제 갱신 건수를 센다.
+     */
+    private fun repositoryForFill(
+        shareCode: String,
+        staleCount: Int,
+    ): Pair<ScheduleRepository, WriteBatch> {
+        val user = mockk<FirebaseUser>()
+        every { user.uid } returns uid
+        val auth = mockk<FirebaseAuth>()
+        every { auth.currentUser } returns user
+
+        val userSnapshot = mockk<DocumentSnapshot>()
+        every { userSnapshot.getString("shareCode") } returns shareCode
+        val userDocRef = mockk<DocumentReference>()
+        every { userDocRef.get() } returns Tasks.forResult(userSnapshot)
+        val usersCollection = mockk<CollectionReference>()
+        every { usersCollection.document(uid) } returns userDocRef
+
+        val stale =
+            (1..staleCount).map {
+                mockk<DocumentSnapshot>().also { document ->
+                    every { document.reference } returns mockk<DocumentReference>()
+                }
+            }
+        val querySnapshot = mockk<QuerySnapshot>()
+        every { querySnapshot.documents } returns stale
+        val byShareCode = mockk<Query>()
+        every { byShareCode.get() } returns Tasks.forResult(querySnapshot)
+        val byUser = mockk<Query>()
+        every { byUser.whereEqualTo("sharedCode", "") } returns byShareCode
+        val schedulesCollection = mockk<CollectionReference>()
+        every { schedulesCollection.whereEqualTo("userId", uid) } returns byUser
+
+        val batch = mockk<WriteBatch>()
+        every { batch.update(any<DocumentReference>(), any<Map<String, Any>>()) } returns batch
+        every { batch.commit() } returns Tasks.forResult(null)
+
+        val firestore = mockk<FirebaseFirestore>()
+        every { firestore.collection("schedules") } returns schedulesCollection
+        every { firestore.collection("users") } returns usersCollection
+        every { firestore.batch() } returns batch
+
+        return ScheduleRepository(auth, firestore) to batch
+    }
+
+    @Test
+    fun `코드 없이 저장된 일정에 공유 코드를 채운다`() =
+        runTest {
+            // 코드가 빈 채로 저장된 일정은 보안 규칙의 공유 읽기가 sharedCode != "" 를 요구해
+            // 가족이 어떤 코드로도 읽지 못한다. 코드를 만든 자리에서 함께 맞춘다(#178).
+            val (repository, batch) = repositoryForFill(shareCode = "ABC123", staleCount = 3)
+
+            assertEquals(3, repository.fillMissingSharedCode(uid))
+            verify(exactly = 3) { batch.update(any<DocumentReference>(), any<Map<String, Any>>()) }
+            verify(exactly = 1) { batch.commit() }
+        }
+
+    @Test
+    fun `채울 일정이 없으면 아무것도 쓰지 않는다`() =
+        runTest {
+            val (repository, batch) = repositoryForFill(shareCode = "ABC123", staleCount = 0)
+
+            assertEquals(0, repository.fillMissingSharedCode(uid))
+            verify(exactly = 0) { batch.commit() }
+        }
+
+    @Test
+    fun `내 공유 코드가 아직 없으면 일정을 건드리지 않는다`() =
+        runTest {
+            // 빈 코드로 덮어쓰면 아무것도 고쳐지지 않고 updatedAt 만 흔들린다.
+            val (repository, batch) = repositoryForFill(shareCode = "", staleCount = 3)
+
+            assertEquals(0, repository.fillMissingSharedCode(uid))
+            verify(exactly = 0) { batch.update(any<DocumentReference>(), any<Map<String, Any>>()) }
         }
 
     @Test

--- a/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/java/com/example/slowclock/ui/profile/ProfileViewModel.kt
@@ -2,6 +2,7 @@ package com.example.slowclock.ui.profile
 
 import androidx.lifecycle.viewModelScope
 import com.example.slowclock.data.remote.repository.AuthRepository
+import com.example.slowclock.data.remote.repository.ScheduleRepository
 import com.example.slowclock.data.remote.repository.UserRepository
 import com.example.slowclock.domain.profile.DeleteAccountResult
 import com.example.slowclock.domain.profile.DeleteAccountStep
@@ -18,6 +19,7 @@ class ProfileViewModel
     constructor(
         private val userRepository: UserRepository,
         private val authRepository: AuthRepository,
+        private val scheduleRepository: ScheduleRepository,
         private val deleteAccount: DeleteAccountUseCase,
         private val signOutUseCase: SignOutUseCase,
     ) : MviViewModel<ProfileIntent, ProfileUiState, ProfileReducerEvent>(ProfileUiState()) {
@@ -116,6 +118,9 @@ class ProfileViewModel
                         email = profile.email,
                     )
                 if (created) {
+                    // 코드만 만들면 그 전에 저장한 일정은 sharedCode 가 빈 채라 가족이 영영
+                    // 못 읽는다. 다시 시도 버튼이 「고쳤다」 는 잘못된 안심을 주면 안 된다(#178).
+                    scheduleRepository.fillMissingSharedCode(profile.uid)
                     dispatch(ProfileReducerEvent.ShareCodeRetryFinished())
                     loadProfile()
                 } else {

--- a/feature/profile/src/test/java/com/example/slowclock/ui/profile/ProfileViewModelTest.kt
+++ b/feature/profile/src/test/java/com/example/slowclock/ui/profile/ProfileViewModelTest.kt
@@ -2,6 +2,7 @@ package com.example.slowclock.ui.profile
 
 import com.example.slowclock.data.model.User
 import com.example.slowclock.data.remote.repository.AuthRepository
+import com.example.slowclock.data.remote.repository.ScheduleRepository
 import com.example.slowclock.data.remote.repository.UserRepository
 import com.example.slowclock.domain.profile.DeleteAccountResult
 import com.example.slowclock.domain.profile.DeleteAccountStep
@@ -37,6 +38,7 @@ class ProfileViewModelTest {
     private val authRepository = mockk<AuthRepository>()
     private val deleteAccount = mockk<DeleteAccountUseCase>()
     private val signOutUseCase = mockk<SignOutUseCase>(relaxed = true)
+    private val scheduleRepository = mockk<ScheduleRepository>()
 
     @Before
     fun setUp() {
@@ -46,6 +48,7 @@ class ProfileViewModelTest {
         coEvery { userRepository.getCurrentUser() } returns
             User(id = "uid-1", name = "정일혁", email = "user@example.com", shareCode = "ABC123")
         justRun { authRepository.signOut() }
+        coEvery { scheduleRepository.fillMissingSharedCode(any()) } returns 0
     }
 
     @After
@@ -53,7 +56,7 @@ class ProfileViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = ProfileViewModel(userRepository, authRepository, deleteAccount, signOutUseCase)
+    private fun createViewModel() = ProfileViewModel(userRepository, authRepository, scheduleRepository, deleteAccount, signOutUseCase)
 
     @Test
     fun `Firestore 사용자 문서로 이름·이메일·공유 코드를 채운다`() =
@@ -179,6 +182,34 @@ class ProfileViewModelTest {
 
             assertEquals("XYZ789", viewModel.uiState.value.shareCode)
             assertFalse(viewModel.uiState.value.isRetryingShareCode)
+        }
+
+    @Test
+    fun `공유 코드를 만들면 코드 없이 저장된 일정도 함께 맞춘다`() =
+        runTest {
+            // 코드만 만들면 그 전에 저장한 일정은 sharedCode 가 빈 채라 가족이 영영 못 읽는다.
+            // 다시 시도 버튼이 「고쳤다」 는 잘못된 안심을 주면 안 된다(#178).
+            coEvery { userRepository.getCurrentUser() } returns
+                User(id = "uid-1", name = "정일혁", email = "user@example.com", shareCode = "")
+            coEvery { userRepository.ensureShareCode("uid-1", any(), any()) } returns true
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(ProfileIntent.RetryShareCode)
+
+            coVerify(exactly = 1) { scheduleRepository.fillMissingSharedCode("uid-1") }
+        }
+
+    @Test
+    fun `공유 코드를 못 만들면 일정은 건드리지 않는다`() =
+        runTest {
+            coEvery { userRepository.getCurrentUser() } returns
+                User(id = "uid-1", name = "정일혁", email = "user@example.com", shareCode = "")
+            coEvery { userRepository.ensureShareCode(any(), any(), any()) } returns false
+            val viewModel = createViewModel()
+
+            viewModel.onIntent(ProfileIntent.RetryShareCode)
+
+            coVerify(exactly = 0) { scheduleRepository.fillMissingSharedCode(any()) }
         }
 
     @Test


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #178

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 공유 코드가 비어 있던 동안 만든 일정도 코드를 만들면 가족에게 보입니다. 전에는 그 일정만 영영 안 보였습니다
- 내 정보 화면의 「공유 코드 다시 만들기」 가 이미 저장된 일정까지 함께 고칩니다

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

## 무엇이 문제였나

일정은 저장할 때의 공유 코드를 문서에 굳혀 넣는다(`ScheduleRepository.addSchedule`). 신호가 약한 곳에서 처음 로그인하면 코드가 비어 있고, 그 사이에 만든 일정은 `sharedCode` 가 빈 문자열로 저장된다.

보안 규칙의 공유 읽기는 `sharedCode != ""` 를 요구한다. 그래서 나중에 코드를 만들어도 **그 일정들은 가족이 어떤 코드로도 읽지 못한다.**

사용자 쪽에서 보이는 것은 이렇다. 코드를 만들었고, 가족에게 알려 줬고, 가족 앱에는 아무것도 안 뜬다. 화면 어디에도 이유가 없다. 「공유 코드 다시 만들기」(#134)는 사용자 문서만 고쳐서, 눌러도 아무것도 달라지지 않는데 「고쳤다」 는 안심만 준다.

## 어떻게 고쳤나

코드를 보장하는 자리 뒤에서 코드가 빈 내 일정에 코드를 채운다. 두 자리 모두 지난다 — 로그인 직후(`AuthManager`)와 내 정보 화면의 다시 시도 버튼(`ProfileViewModel`).

- 코드가 빈 일정만 고른다(`userId` + `sharedCode == ""`). 이미 코드가 있는 일정은 건드리지 않는다
- 내 공유 코드가 아직 없으면 아무것도 쓰지 않는다. 빈 코드로 덮어쓰면 고쳐지는 것 없이 `updatedAt` 만 흔들린다
- 실패해도 던지지 않는다. 코드 만들기 결과를 이 일이 뒤집으면 안 되고, 다음 로그인에서 다시 맞추면 된다

## 확인

- 코드 없이 저장된 일정 3건에 코드를 채우고 batch 를 한 번 커밋한다
- 채울 일정이 없으면 아무것도 쓰지 않는다
- 내 코드가 아직 없으면 일정을 건드리지 않는다
- 코드를 만들면 일정 맞추기를 부르고, 못 만들면 부르지 않는다

단위 테스트 통과. lint · ktlint 통과.
