### PR TITLE
fix: 컨벤션 의존성과 빌드 정책 변경을 CI 영향 범위에 반영한다

### DIFF
--- a/.github/scripts/resolve-pr-impact.mjs
+++ b/.github/scripts/resolve-pr-impact.mjs
@@ -11,6 +11,13 @@ const JVM_LIBRARY_PLUGIN_PATTERN =
     /id\("(?:java-library|org\.jetbrains\.kotlin\.jvm)"\)|alias\(libs\.plugins\.kotlin\.jvm\)/;
 const ANDROID_TEST_PLUGIN_PATTERN =
     /(?:id\("com\.android\.test"\)|alias\(libs\.plugins\.android\.test\))/;
+const CONVENTION_PLUGIN_SOURCES = new Map([
+    ["slowclock.android.application", "AndroidApplicationConventionPlugin.kt"],
+    ["slowclock.android.library", "AndroidLibraryConventionPlugin.kt"],
+    ["slowclock.android.library.compose", "AndroidLibraryComposeConventionPlugin.kt"],
+    ["slowclock.android.hilt", "AndroidHiltConventionPlugin.kt"],
+    ["slowclock.android.feature", "AndroidFeatureConventionPlugin.kt"],
+]);
 const GLOBAL_GRADLE_PATHS = new Set([
     "build.gradle.kts",
     "settings.gradle.kts",
@@ -236,6 +243,11 @@ export function resolvePrImpact(changedFiles, modules, dependencies) {
         }
         if (filePath === `${module.directory}/build.gradle.kts`) {
             codeqlJavaKotlin = true;
+            // 배포 정책 테스트는 이 파일의 R8·리소스 축소·버전 설정도 읽는다.
+            runNodeTests = true;
+        }
+        if (relative.endsWith(".pro")) {
+            runNodeTests = true;
         }
 
         if (relative.startsWith("src/test/") || relative.startsWith("src/testDebug/")) {
@@ -254,6 +266,10 @@ export function resolvePrImpact(changedFiles, modules, dependencies) {
         }
     }
 
+    if (productionSeeds.size > 0 && modules.some(({ unresolvedConvention }) => unresolvedConvention)) {
+        // 모르는 컨벤션이 있으면 역의존 그래프가 불완전할 수 있다.
+        forceFull = true;
+    }
     if (forceFull || globalGradleChange) {
         productionSeeds.clear();
         allProjects.forEach((projectPath) => productionSeeds.add(projectPath));
@@ -346,19 +362,66 @@ export async function inspectModules(root) {
         (match) => match[1],
     );
     const modules = [];
+    const conventionSourceCache = new Map();
     for (const projectPath of projectPaths) {
         const directory = moduleDirectory(projectPath);
         const buildFile = path.join(root, directory, "build.gradle.kts");
         const source = await fs.readFile(buildFile, "utf8");
+        const convention = await inspectConventionSources(root, source, conventionSourceCache);
         modules.push({
             projectPath,
             directory,
             android: isAndroidModuleBuild(source),
             screenshot: await pathExists(path.join(root, directory, "src", "screenshotTest")),
             buildSource: source,
+            ...convention,
         });
     }
     return modules;
+}
+
+function conventionPluginIds(source) {
+    const ids = new Set();
+    for (const match of source.matchAll(/\b(?:id|apply)\s*\(\s*"(slowclock\.[A-Za-z0-9_.-]+)"\s*\)/g)) {
+        ids.add(match[1]);
+    }
+    for (const match of source.matchAll(/\balias\s*\(\s*libs\.plugins\.(slowclock\.[A-Za-z0-9_.]+)\s*\)/g)) {
+        ids.add(match[1]);
+    }
+    return ids;
+}
+
+async function inspectConventionSources(root, buildSource, sourceCache) {
+    const dependencySources = [buildSource];
+    const pending = [...conventionPluginIds(buildSource)];
+    const visited = new Set();
+    let unresolvedConvention = false;
+    for (const pluginId of pending) {
+        if (visited.has(pluginId)) continue;
+        visited.add(pluginId);
+        const filename = CONVENTION_PLUGIN_SOURCES.get(pluginId);
+        if (!filename) {
+            unresolvedConvention = true;
+            continue;
+        }
+        if (!sourceCache.has(filename)) {
+            const sourcePath = path.join(root, "build-logic/convention/src/main/kotlin", filename);
+            try {
+                sourceCache.set(filename, await fs.readFile(sourcePath, "utf8"));
+            } catch (error) {
+                if (error.code !== "ENOENT") throw error;
+                sourceCache.set(filename, null);
+            }
+        }
+        const source = sourceCache.get(filename);
+        if (source === null) {
+            unresolvedConvention = true;
+            continue;
+        }
+        dependencySources.push(source);
+        pending.push(...conventionPluginIds(source));
+    }
+    return { dependencySources, unresolvedConvention };
 }
 
 export function inspectDependencies(modules) {
@@ -370,13 +433,15 @@ export function inspectDependencies(modules) {
 
     for (const module of modules) {
         const consumed = new Set();
-        for (const match of module.buildSource.matchAll(/projects\.([A-Za-z0-9_.]+)/g)) {
+        // 컨벤션의 project 의존도 실제 소스에서 읽어 간선 목록을 따로 유지하지 않는다.
+        const source = (module.dependencySources ?? [module.buildSource]).join("\n");
+        for (const match of source.matchAll(/projects\.([A-Za-z0-9_.]+)/g)) {
             const projectPath = accessorToProject.get(match[1]);
             if (projectPath && projectPath !== module.projectPath) {
                 consumed.add(projectPath);
             }
         }
-        for (const match of module.buildSource.matchAll(/project\(\s*"(:[^"]+)"\s*\)/g)) {
+        for (const match of source.matchAll(/project\(\s*"(:[^"]+)"\s*\)/g)) {
             if (knownProjects.has(match[1]) && match[1] !== module.projectPath) {
                 consumed.add(match[1]);
             }

--- a/.github/scripts/resolve-pr-impact.test.mjs
+++ b/.github/scripts/resolve-pr-impact.test.mjs
@@ -1,14 +1,19 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
+    analyzeRepositoryImpact,
     changedPathsFromGithubFiles,
     githubOutputLines,
     isAndroidModuleBuild,
     resolvePrImpact,
 } from "./resolve-pr-impact.mjs";
 
-// settings.gradle.kts 의 실제 모듈 구성을 본뜬 fixture. :app 만 screenshotTest 소스셋을 갖는다.
+// 영향 전파 알고리즘용 축약 fixture. 실제 저장소 탐색은 별도 통합 회귀로 확인한다.
 const modules = [
     module(":app", { screenshot: true }),
     module(":core:model"),
@@ -232,6 +237,7 @@ test("a module build script change compiles for CodeQL and lints the module", ()
     const impact = resolvePrImpact(["core/data/build.gradle.kts"], modules, dependencies);
 
     assert.equal(impact.codeqlJavaKotlin, true);
+    assert.equal(impact.runNodeTests, true);
     assert.deepEqual(impact.ktlintTasks, [":core:data:ktlintCheck"]);
     assert.deepEqual(impact.androidLintTasks, [
         ":app:lintDebug",
@@ -240,4 +246,92 @@ test("a module build script change compiles for CodeQL and lints the module", ()
         ":feature:main:lintDebug",
         ":app:processDebugMainManifest",
     ]);
+});
+
+test("module build and R8 rule changes run Node policy tests without forcing unrelated Gradle work", () => {
+    for (const filePath of ["app/build.gradle.kts", "app/proguard-rules.pro"]) {
+        const impact = resolvePrImpact([filePath], modules, dependencies);
+
+        assert.equal(impact.runNodeTests, true, filePath);
+        assert.deepEqual(impact.unitTestModules, [":app"], filePath);
+        assert.equal(impact.repositoryQualityFull, false, filePath);
+    }
+});
+
+test("real core UI and data changes validate convention consumers and their screenshot baselines", async () => {
+    const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+    for (const filename of [
+        "core/ui/src/main/java/com/example/slowclock/ui/theme/Color.kt",
+        "core/data/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt",
+    ]) {
+        const impact = await analyzeRepositoryImpact(repositoryRoot, [{ filename }]);
+
+        for (const consumer of [":feature:main", ":feature:addschedule", ":feature:profile"]) {
+            assert.ok(impact.unitTestTasks.includes(`${consumer}:testDebugUnitTest`), `${filename}: ${consumer}`);
+            assert.ok(impact.androidLintTasks.includes(`${consumer}:lintDebug`), `${filename}: ${consumer}`);
+        }
+        assert.ok(impact.screenshotTasks.includes(":feature:main:validateScreenshotTest"), filename);
+        assert.equal(impact.repositoryQualityFull, false, filename);
+    }
+});
+
+async function conventionFixture(t, featurePlugin, conventionSources = {}) {
+    const root = await mkdtemp(join(tmpdir(), "slowclock-impact-"));
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const projects = [":app", ":core:ui", ":core:data", ":core:common", ":feature:main"];
+    const files = {
+        "settings.gradle.kts": projects.map((name) => `include("${name}")`).join("\n"),
+        ...Object.fromEntries(projects.map((name) => [
+            `${name.slice(1).replaceAll(":", "/")}/build.gradle.kts`,
+            name === ":feature:main" ? `plugins { ${featurePlugin} }` : 'plugins { id("com.android.library") }',
+        ])),
+        ...Object.fromEntries(Object.entries(conventionSources).map(([name, source]) => [
+            `build-logic/convention/src/main/kotlin/${name}.kt`, source,
+        ])),
+    };
+    await Promise.all(Object.entries(files).map(async ([name, source]) => {
+        await mkdir(dirname(join(root, name)), { recursive: true });
+        await writeFile(join(root, name), source);
+    }));
+    await mkdir(join(root, "feature/main/src/screenshotTest"), { recursive: true });
+    return root;
+}
+
+test("direct IDs and catalog aliases follow nested conventions and changed dependency declarations", async (t) => {
+    for (const plugin of ['id("slowclock.android.feature")', "alias(libs.plugins.slowclock.android.feature)"]) {
+        const root = await conventionFixture(t, plugin, {
+            AndroidFeatureConventionPlugin: 'pluginManager.apply("slowclock.android.library")',
+            AndroidLibraryConventionPlugin: 'add("implementation", project(":core:common"))',
+        });
+        const impact = await analyzeRepositoryImpact(root, [{ filename: "core/common/src/main/Value.kt" }]);
+        assert.deepEqual(impact.unitTestModules, [":core:common", ":feature:main"], plugin);
+        assert.deepEqual(impact.screenshotModules, [":feature:main"], plugin);
+        assert.equal(impact.repositoryQualityFull, false, plugin);
+
+        // 플러그인의 의존을 바꾸면 계산기 안의 별도 간선 목록 수정 없이 다음 분석에 반영된다.
+        await writeFile(
+            join(root, "build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt"),
+            'add("implementation", project(":core:data"))',
+        );
+        const changed = await analyzeRepositoryImpact(root, [{ filename: "core/data/src/main/Value.kt" }]);
+        assert.deepEqual(changed.unitTestModules, [":core:data", ":feature:main"], plugin);
+    }
+});
+
+test("unknown or missing convention sources widen production validation instead of omitting consumers", async (t) => {
+    for (const plugin of [
+        'id("slowclock.android.feature")',
+        'id("slowclock.android.new")',
+        "alias(libs.plugins.slowclock.android.new)",
+    ]) {
+        const root = await conventionFixture(t, plugin);
+        const impact = await analyzeRepositoryImpact(root, [{ filename: "core/ui/src/main/Value.kt" }]);
+        assert.equal(impact.repositoryQualityFull, true, plugin);
+        assert.equal(impact.runNodeTests, true, plugin);
+        assert.deepEqual(impact.unitTestModules, [":app", ":core:common", ":core:data", ":core:ui", ":feature:main"], plugin);
+        assert.deepEqual(impact.screenshotModules, [":feature:main"], plugin);
+
+        const docs = await analyzeRepositoryImpact(root, [{ filename: "README.md" }]);
+        assert.deepEqual(docs.unitTestTasks, [], plugin);
+    }
 });


### PR DESCRIPTION
## 📌 Issues
- Closes #187

## 📎 Work Description
- 공용 코드를 고치면 그 코드를 사용하는 기능의 테스트와 화면 검사를 함께 실행합니다.
- 릴리스 빌드와 난독화 설정 변경도 배포 정책 검사에서 확인합니다.

## 📷 Screenshot
화면 변경 없음.

## 💬 To Reviewers
컨벤션 플러그인 적용 체인의 실제 소스에서 모듈 의존성을 읽습니다. 알 수 없거나 소스가 없는 컨벤션은 보수적으로 전체 검사를 실행합니다. 모듈 Gradle 파일과 ProGuard 규칙 변경은 Node 정책 테스트도 선택합니다.

검증: 실제 저장소의 core:ui/core:data 변경에서 feature:main의 unit/lint/screenshot 선택 확인. 직접 ID·alias·중첩 컨벤션·의존 변경·누락 fallback 회귀 포함. 최신 main 통합 뒤 Node 전체 263개, repository-quality 및 실패 fixture 통과.
