### PR TITLE
일정 편집 입력과 최신 저장 상태를 보존한다

### DIFF
--- a/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
@@ -1,5 +1,6 @@
 package com.example.slowclock.navigation
 
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -115,7 +116,7 @@ fun AppNavigation(
     ) { innerPadding ->
         NavDisplay(
             backStack = backStack,
-            modifier = Modifier.padding(innerPadding),
+            modifier = Modifier.padding(innerPadding).consumeWindowInsets(innerPadding),
             onBack = {
                 recommendation = recommendation?.afterLeaving(backStack.lastOrNull())
                 backStack.popBack()

--- a/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/slowclock/navigation/AppNavigation.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -82,14 +83,20 @@ private fun NavBackStack<NavKey>.showTab(key: SlowClockKey) {
     if (key != MainKey) add(key)
 }
 
+private val recommendationSaver =
+    listSaver<ScheduleRecommendation?, String>(
+        save = { value -> value?.let { listOf(it.target, it.title) } ?: emptyList() },
+        restore = { values -> if (values.size == 2) ScheduleRecommendation(values[0], values[1]) else null },
+    )
+
 @Composable
 fun AppNavigation(
     onSignIn: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val backStack = rememberNavBackStack(MainKey)
-    // 추천 화면이 고른 제목. 일정 추가 entry 를 바꾸지 않고 전달하므로 그 화면의 ViewModel 이 유지된다.
-    var recommendedTitle by rememberSaveable { mutableStateOf<String?>(null) }
+    // 대상 entry 를 바꾸지 않고 결과만 전달하므로 입력 중인 ViewModel 이 유지된다.
+    var recommendation by rememberSaveable(stateSaver = recommendationSaver) { mutableStateOf<ScheduleRecommendation?>(null) }
     val currentRoute = backStack.lastOrNull()?.tabRoute()
 
     Scaffold(
@@ -109,7 +116,10 @@ fun AppNavigation(
         NavDisplay(
             backStack = backStack,
             modifier = Modifier.padding(innerPadding),
-            onBack = { backStack.popBack() },
+            onBack = {
+                recommendation = recommendation?.afterLeaving(backStack.lastOrNull())
+                backStack.popBack()
+            },
             entryDecorators =
                 listOf(
                     rememberSaveableStateHolderNavEntryDecorator(),
@@ -131,9 +141,10 @@ fun AppNavigation(
                     entry<SettingsKey> { SettingsScreen() }
                     entry<AddScheduleKey> {
                         AddScheduleScreen(
-                            initialTitle = recommendedTitle,
+                            initialTitle = recommendation?.titleFor(AddScheduleKey),
+                            onInitialTitleConsume = { recommendation = null },
                             onNavigateBack = {
-                                recommendedTitle = null
+                                recommendation = null
                                 backStack.popBack()
                             },
                             onNavigateToRecommendation = { backStack.add(RecommendationKey) },
@@ -142,14 +153,19 @@ fun AppNavigation(
                     entry<EditScheduleKey> { key ->
                         AddScheduleScreen(
                             scheduleId = key.scheduleId,
-                            onNavigateBack = { backStack.popBack() },
+                            initialTitle = recommendation?.titleFor(key),
+                            onInitialTitleConsume = { recommendation = null },
+                            onNavigateBack = {
+                                recommendation = null
+                                backStack.popBack()
+                            },
                             onNavigateToRecommendation = { backStack.add(RecommendationKey) },
                         )
                     }
                     entry<RecommendationKey> {
                         RecommendationScreen(
                             onSelectRecommendation = { title ->
-                                recommendedTitle = title
+                                recommendation = ScheduleRecommendation.selected(backStack, title)
                                 backStack.popBack()
                             },
                         )

--- a/app/src/main/java/com/example/slowclock/navigation/ScheduleRecommendation.kt
+++ b/app/src/main/java/com/example/slowclock/navigation/ScheduleRecommendation.kt
@@ -1,0 +1,32 @@
+package com.example.slowclock.navigation
+
+import androidx.navigation3.runtime.NavKey
+
+/** 추천 결과는 추천 화면 바로 아래에서 기다리는 일정 편집 화면 한 곳에만 전달한다. */
+internal data class ScheduleRecommendation(
+    val target: String,
+    val title: String,
+) {
+    fun titleFor(editor: NavKey): String? = title.takeIf { editor.editorToken() == target }
+
+    fun afterLeaving(screen: NavKey?): ScheduleRecommendation? =
+        takeUnless { screen == RecommendationKey || screen?.editorToken() == target }
+
+    companion object {
+        fun selected(
+            backStack: List<NavKey>,
+            title: String,
+        ): ScheduleRecommendation? {
+            if (backStack.lastOrNull() != RecommendationKey) return null
+            val target = backStack.getOrNull(backStack.lastIndex - 1)?.editorToken() ?: return null
+            return ScheduleRecommendation(target, title)
+        }
+    }
+}
+
+private fun NavKey.editorToken(): String? =
+    when (this) {
+        AddScheduleKey -> "add"
+        is EditScheduleKey -> "edit:$scheduleId"
+        else -> null
+    }

--- a/app/src/test/java/com/example/slowclock/navigation/ScheduleRecommendationTest.kt
+++ b/app/src/test/java/com/example/slowclock/navigation/ScheduleRecommendationTest.kt
@@ -1,0 +1,45 @@
+package com.example.slowclock.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ScheduleRecommendationTest {
+    @Test
+    fun `추가 화면에서 받은 추천은 추가 화면에만 전달한다`() {
+        val result = ScheduleRecommendation.selected(listOf(MainKey, AddScheduleKey, RecommendationKey), "약 먹기")!!
+
+        assertEquals("약 먹기", result.titleFor(AddScheduleKey))
+        assertNull(result.titleFor(EditScheduleKey("s1")))
+    }
+
+    @Test
+    fun `편집 화면에서 받은 추천은 그 일정에만 전달한다`() {
+        val editor = EditScheduleKey("s1")
+        val result = ScheduleRecommendation.selected(listOf(MainKey, editor, RecommendationKey), "산책")!!
+
+        assertEquals("산책", result.titleFor(editor))
+        assertNull(result.titleFor(EditScheduleKey("s2")))
+        assertNull(result.titleFor(AddScheduleKey))
+    }
+
+    @Test
+    fun `대상 폼에서 시스템 뒤로가기를 하면 다음 폼에 추천이 남지 않는다`() {
+        val result = ScheduleRecommendation.selected(listOf(MainKey, AddScheduleKey, RecommendationKey), "약 먹기")!!
+
+        assertNull(result.afterLeaving(AddScheduleKey))
+    }
+
+    @Test
+    fun `추천 화면을 취소하면 남아 있던 결과도 지운다`() {
+        val result = ScheduleRecommendation.selected(listOf(MainKey, EditScheduleKey("s1"), RecommendationKey), "산책")!!
+
+        assertNull(result.afterLeaving(RecommendationKey))
+    }
+
+    @Test
+    fun `바로 아래에 일정 폼이 없으면 추천 결과를 전달하지 않는다`() {
+        assertNull(ScheduleRecommendation.selected(listOf(MainKey, RecommendationKey), "약 먹기"))
+        assertNull(ScheduleRecommendation.selected(listOf(MainKey, AddScheduleKey), "약 먹기"))
+    }
+}

--- a/core/data/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt
+++ b/core/data/src/main/java/com/example/slowclock/data/remote/repository/ScheduleRepository.kt
@@ -303,18 +303,23 @@ class ScheduleRepository
                 return ScheduleResult.Error(AppError.InvalidDataError)
             }
 
-            // Always preserve sharedCode and all fields from the original schedule
-            val updatedSchedule =
-                schedule.copy(
-                    userId = uid, // 현재 사용자 ID로 강제 설정
-                    updatedAt = Timestamp.now(),
-                    sharedCode = schedule.sharedCode, // ensure sharedCode is preserved
+            // 편집 화면이 바꾼 필드만 쓴다. 읽은 뒤 바뀐 완료 기록·공유 코드·소유자를 되돌리거나,
+            // 이미 삭제된 문서를 set 으로 다시 만들지 않는다.
+            val changes =
+                mapOf(
+                    "title" to schedule.title,
+                    "description" to schedule.description,
+                    "startTime" to schedule.startTime,
+                    "endTime" to schedule.endTime,
+                    "recurring" to schedule.recurring,
+                    "recurringType" to schedule.recurringType,
+                    "updatedAt" to Timestamp.now(),
                 )
 
             return try {
                 schedulesCollection
                     .document(schedule.id)
-                    .set(updatedSchedule)
+                    .update(changes)
                     .await()
 
                 Log.d("ScheduleRepo", "일정 수정 성공: ${schedule.id}")

--- a/core/data/src/test/java/com/example/slowclock/data/remote/repository/ScheduleRepositoryUpdateTest.kt
+++ b/core/data/src/test/java/com/example/slowclock/data/remote/repository/ScheduleRepositoryUpdateTest.kt
@@ -1,0 +1,116 @@
+package com.example.slowclock.data.remote.repository
+
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.util.AppError
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Date
+
+class ScheduleRepositoryUpdateTest {
+    private val updatedFields = slot<Map<String, Any?>>()
+    private val document = mockk<DocumentReference>()
+
+    private fun repositoryWith(response: Task<Void>): ScheduleRepository {
+        val user = mockk<FirebaseUser>()
+        every { user.uid } returns "owner"
+        val auth = mockk<FirebaseAuth>()
+        every { auth.currentUser } returns user
+        every { document.update(capture(updatedFields)) } returns response
+        val schedules = mockk<CollectionReference>()
+        every { schedules.document("s1") } returns document
+        val firestore = mockk<FirebaseFirestore>()
+        every { firestore.collection("schedules") } returns schedules
+        every { firestore.collection("users") } returns mockk()
+        return ScheduleRepository(auth, firestore)
+    }
+
+    @Test
+    fun `편집은 서버의 완료 기록 공유 코드 소유자 생성 시각을 덮지 않는다`() =
+        runTest {
+            val repository = repositoryWith(Tasks.forResult(null))
+            val originalCreatedAt = Timestamp(Date(1_700_000_000_000))
+            val currentServer =
+                mutableMapOf<String, Any?>(
+                    "userId" to "owner",
+                    "sharedCode" to "NEW123",
+                    "familyGroupId" to "family",
+                    "completed" to true,
+                    "completedDates" to listOf("2032-01-05"),
+                    "createdAt" to originalCreatedAt,
+                )
+            val staleForm =
+                Schedule(
+                    id = "s1",
+                    userId = "old-owner",
+                    sharedCode = "OLD123",
+                    title = "새 제목",
+                    description = "새 설명",
+                    startTime = Timestamp(Date(1_900_000_000_000)),
+                    endTime = null,
+                    recurring = true,
+                    recurringType = "weekly",
+                    completed = false,
+                    completedDates = emptyList(),
+                )
+
+            assertTrue(repository.updateSchedule(staleForm) is ScheduleRepository.ScheduleResult.Success)
+            currentServer.putAll(updatedFields.captured)
+
+            assertEquals("owner", currentServer["userId"])
+            assertEquals("NEW123", currentServer["sharedCode"])
+            assertEquals("family", currentServer["familyGroupId"])
+            assertEquals(true, currentServer["completed"])
+            assertEquals(listOf("2032-01-05"), currentServer["completedDates"])
+            assertEquals(originalCreatedAt, currentServer["createdAt"])
+            assertEquals("새 제목", currentServer["title"])
+            assertEquals("새 설명", currentServer["description"])
+            assertEquals(staleForm.startTime, currentServer["startTime"])
+            assertEquals(true, currentServer["recurring"])
+            assertEquals("weekly", currentServer["recurringType"])
+            assertTrue(currentServer["updatedAt"] is Timestamp)
+            verify(exactly = 0) { document.set(any()) }
+        }
+
+    @Test
+    fun `종료 시각과 반복을 지우면 null도 갱신에 포함한다`() =
+        runTest {
+            val repository = repositoryWith(Tasks.forResult(null))
+
+            repository.updateSchedule(Schedule(id = "s1", title = "일정", endTime = null, recurring = false, recurringType = null))
+
+            assertTrue(updatedFields.captured.containsKey("endTime"))
+            assertNull(updatedFields.captured["endTime"])
+            assertFalse(updatedFields.captured["recurring"] as Boolean)
+            assertTrue(updatedFields.captured.containsKey("recurringType"))
+            assertNull(updatedFields.captured["recurringType"])
+        }
+
+    @Test
+    fun `이미 삭제된 일정의 편집은 문서를 재생성하지 않고 찾을 수 없음으로 끝난다`() =
+        runTest {
+            val missing = FirebaseFirestoreException("missing", FirebaseFirestoreException.Code.NOT_FOUND)
+            val repository = repositoryWith(Tasks.forException(missing))
+
+            val result = repository.updateSchedule(Schedule(id = "s1", title = "삭제된 일정"))
+
+            assertEquals(ScheduleRepository.ScheduleResult.Error(AppError.NotFoundError), result)
+            verify(exactly = 0) { document.set(any()) }
+        }
+}

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleContract.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleContract.kt
@@ -24,6 +24,11 @@ sealed interface AddScheduleIntent : MviIntent {
         val time: Calendar?,
     ) : AddScheduleIntent
 
+    data class UpdateTimeInput(
+        val value: ScheduleTimeInput,
+        val isEnd: Boolean = false,
+    ) : AddScheduleIntent
+
     data class UpdateRecurring(
         val recurring: Boolean,
     ) : AddScheduleIntent
@@ -54,6 +59,8 @@ data class AddScheduleUiState(
     val description: String = "",
     val selectedTime: Calendar = Calendar.getInstance(),
     val endTime: Calendar? = null,
+    val startTimeInput: ScheduleTimeInput = ScheduleTimeInput.from(selectedTime),
+    val endTimeInput: ScheduleTimeInput = ScheduleTimeInput.from(endTime),
     val recurring: Boolean = false,
     val recurringType: String = "daily",
     val isLoading: Boolean = false,
@@ -62,8 +69,15 @@ data class AddScheduleUiState(
     val canRetry: Boolean = false,
     val isEditMode: Boolean = false,
     val editingSchedule: Schedule? = null,
+    val editScheduleId: String? = null,
 ) : UiState {
-    val canSave: Boolean get() = title.isNotBlank() && !isLoading
+    val hasValidTimeInput: Boolean get() = startTimeInput.isValid && (endTimeInput.isEmpty || endTimeInput.isValid)
+    val canSave: Boolean get() =
+        title.isNotBlank() && !isLoading && !isSaved && hasValidTimeInput &&
+            (!isEditMode || editingSchedule != null)
+
+    fun canApplyRecommendedTitle(scheduleId: String?): Boolean =
+        !isLoading && !isSaved && (scheduleId.isNullOrBlank() || editingSchedule?.id == scheduleId)
 }
 
 sealed interface AddScheduleReducerEvent : ReducerEvent {
@@ -91,7 +105,14 @@ sealed interface AddScheduleReducerEvent : ReducerEvent {
         val type: String,
     ) : AddScheduleReducerEvent
 
-    data object EditLoading : AddScheduleReducerEvent
+    data class TimeInputChanged(
+        val value: ScheduleTimeInput,
+        val isEnd: Boolean,
+    ) : AddScheduleReducerEvent
+
+    data class EditLoading(
+        val scheduleId: String,
+    ) : AddScheduleReducerEvent
 
     data class EditLoaded(
         val schedule: Schedule,
@@ -111,4 +132,35 @@ sealed interface AddScheduleReducerEvent : ReducerEvent {
     data object ErrorConsumed : AddScheduleReducerEvent
 
     data object SavedConsumed : AddScheduleReducerEvent
+}
+
+/** 입력 중인 빈칸도 보존한다. 저장 가능 여부는 화면과 저장 동작이 같은 값으로 판단한다. */
+data class ScheduleTimeInput(
+    val hour: String = "",
+    val minute: String = "",
+) {
+    val isEmpty: Boolean get() = hour.isEmpty() && minute.isEmpty()
+    val isValid: Boolean get() = hour.toIntOrNull() in 0..23 && minute.toIntOrNull() in 0..59
+
+    fun onDate(date: Calendar): Calendar? =
+        if (isValid) {
+            (date.clone() as Calendar).apply {
+                set(Calendar.HOUR_OF_DAY, hour.toInt())
+                set(Calendar.MINUTE, minute.toInt())
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+        } else {
+            null
+        }
+
+    companion object {
+        fun from(time: Calendar?): ScheduleTimeInput {
+            if (time == null) return ScheduleTimeInput()
+            return ScheduleTimeInput(
+                hour = time.get(Calendar.HOUR_OF_DAY).toString(),
+                minute = time.get(Calendar.MINUTE).toString(),
+            )
+        }
+    }
 }

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -53,15 +54,21 @@ fun AddScheduleScreen(
     modifier: Modifier = Modifier,
     scheduleId: String? = null,
     initialTitle: String? = null,
+    onInitialTitleConsume: () -> Unit = {},
     viewModel: AddScheduleViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val consumeInitialTitle by rememberUpdatedState(onInitialTitleConsume)
 
     LaunchedEffect(scheduleId) {
         if (!scheduleId.isNullOrBlank()) viewModel.onIntent(AddScheduleIntent.LoadForEdit(scheduleId))
     }
-    LaunchedEffect(initialTitle) {
-        if (!initialTitle.isNullOrBlank()) viewModel.onIntent(AddScheduleIntent.UpdateTitle(initialTitle))
+    LaunchedEffect(initialTitle, state.isLoading, state.editingSchedule?.id, state.isSaved) {
+        if (!initialTitle.isNullOrBlank() && viewModel.uiState.value.canApplyRecommendedTitle(scheduleId)) {
+            viewModel.onIntent(AddScheduleIntent.UpdateTitle(initialTitle))
+            // 조회가 끝나 입력에 반영한 뒤에만 소비한다. 회전하거나 다시 돌아와도 덮어쓰지 않는다.
+            consumeInitialTitle()
+        }
     }
     ObserveSignal(
         signal = state.isSaved.takeIf { it },
@@ -73,7 +80,7 @@ fun AddScheduleScreen(
         state = state,
         onIntent = viewModel::onIntent,
         onNavigateBack = onNavigateBack,
-        onNavigateToRecommendation = onNavigateToRecommendation,
+        onNavigateToRecommendation = { if (!state.isLoading && !state.isSaved) onNavigateToRecommendation() },
         modifier = modifier,
     )
 }
@@ -160,10 +167,10 @@ internal fun AddScheduleContent(
             )
 
             TimePickerSection(
-                selectedTime = state.selectedTime,
-                endTime = state.endTime,
-                onTimeSelect = { onIntent(AddScheduleIntent.UpdateTime(it)) },
-                onEndTimeSelect = { onIntent(AddScheduleIntent.UpdateEndTime(it)) },
+                startTime = state.startTimeInput,
+                endTime = state.endTimeInput,
+                onTimeSelect = { onIntent(AddScheduleIntent.UpdateTimeInput(it)) },
+                onEndTimeSelect = { onIntent(AddScheduleIntent.UpdateTimeInput(it, isEnd = true)) },
             )
 
             RecurringSection(

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -32,6 +34,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -95,6 +98,10 @@ internal fun AddScheduleContent(
     onNavigateToRecommendation: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val errorInView = remember { BringIntoViewRequester() }
+    LaunchedEffect(state.error) {
+        if (state.error != null) errorInView.bringIntoView()
+    }
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -186,6 +193,7 @@ internal fun AddScheduleContent(
 
             state.error?.let { error ->
                 Card(
+                    modifier = Modifier.bringIntoViewRequester(errorInView),
                     colors =
                         CardDefaults.cardColors(
                             containerColor = MaterialTheme.colorScheme.errorContainer,
@@ -198,17 +206,17 @@ internal fun AddScheduleContent(
                             style = MaterialTheme.typography.bodyLarge,
                         )
 
-                        if (state.canRetry) {
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            OutlinedButton(
+                                onClick = { onIntent(AddScheduleIntent.ConsumeError) },
+                                modifier = Modifier.weight(1f),
                             ) {
-                                OutlinedButton(
-                                    onClick = { onIntent(AddScheduleIntent.ConsumeError) },
-                                    modifier = Modifier.weight(1f),
-                                ) {
-                                    Text("닫기")
-                                }
+                                Text("닫기")
+                            }
 
+                            if (state.canRetry) {
                                 Button(
                                     onClick = { onIntent(AddScheduleIntent.Retry) },
                                     modifier = Modifier.weight(1f),

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleViewModel.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/AddScheduleViewModel.kt
@@ -9,6 +9,8 @@ import com.example.slowclock.ui.mvi.MviViewModel
 import com.example.slowclock.util.AppError
 import com.google.firebase.Timestamp
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.util.Calendar
 import javax.inject.Inject
@@ -23,7 +25,11 @@ class AddScheduleViewModel
         private val scheduleRepository: ScheduleRepository,
         private val alarmScheduler: AlarmScheduler,
     ) : MviViewModel<AddScheduleIntent, AddScheduleUiState, AddScheduleReducerEvent>(AddScheduleUiState()) {
+        private var editLoadJob: Job? = null
+
         override fun onIntent(intent: AddScheduleIntent) {
+            // 폼이 읽히거나 저장되는 중의 중복 입력·저장은 진행 중인 작업을 바꾸지 않는다.
+            if (currentState.isLoading && (intent !is AddScheduleIntent.LoadForEdit || editLoadJob?.isActive != true)) return
             when (intent) {
                 is AddScheduleIntent.UpdateTitle -> {
                     dispatch(AddScheduleReducerEvent.TitleChanged(intent.value))
@@ -39,6 +45,10 @@ class AddScheduleViewModel
 
                 is AddScheduleIntent.UpdateEndTime -> {
                     dispatch(AddScheduleReducerEvent.EndTimeChanged(intent.time?.copyOf()))
+                }
+
+                is AddScheduleIntent.UpdateTimeInput -> {
+                    dispatch(AddScheduleReducerEvent.TimeInputChanged(intent.value, intent.isEnd))
                 }
 
                 is AddScheduleIntent.UpdateRecurring -> {
@@ -59,7 +69,12 @@ class AddScheduleViewModel
 
                 AddScheduleIntent.Retry -> {
                     dispatch(AddScheduleReducerEvent.ErrorConsumed)
-                    save()
+                    val state = currentState
+                    if (state.isEditMode && state.editingSchedule == null) {
+                        state.editScheduleId?.let(::loadForEdit)
+                    } else {
+                        save()
+                    }
                 }
 
                 AddScheduleIntent.ConsumeError -> {
@@ -86,11 +101,11 @@ class AddScheduleViewModel
                 }
 
                 is AddScheduleReducerEvent.TimeChanged -> {
-                    state.copy(selectedTime = event.time)
+                    state.copy(selectedTime = event.time, startTimeInput = ScheduleTimeInput.from(event.time))
                 }
 
                 is AddScheduleReducerEvent.EndTimeChanged -> {
-                    state.copy(endTime = event.time)
+                    state.copy(endTime = event.time, endTimeInput = ScheduleTimeInput.from(event.time))
                 }
 
                 is AddScheduleReducerEvent.RecurringChanged -> {
@@ -101,8 +116,35 @@ class AddScheduleViewModel
                     state.copy(recurringType = event.type)
                 }
 
-                AddScheduleReducerEvent.EditLoading -> {
-                    state.copy(isLoading = true, error = null, isEditMode = true)
+                is AddScheduleReducerEvent.TimeInputChanged -> {
+                    if (event.isEnd) {
+                        state.copy(
+                            endTimeInput = event.value,
+                            endTime =
+                                if (event.value.isEmpty) {
+                                    null
+                                } else {
+                                    event.value.onDate(state.endTime ?: state.selectedTime)
+                                        ?: state.endTime
+                                },
+                        )
+                    } else {
+                        state.copy(
+                            startTimeInput = event.value,
+                            selectedTime = event.value.onDate(state.selectedTime) ?: state.selectedTime,
+                        )
+                    }
+                }
+
+                is AddScheduleReducerEvent.EditLoading -> {
+                    state.copy(
+                        isLoading = true,
+                        error = null,
+                        isEditMode = true,
+                        editingSchedule = null,
+                        editScheduleId = event.scheduleId,
+                        canRetry = false,
+                    )
                 }
 
                 is AddScheduleReducerEvent.EditLoaded -> {
@@ -111,6 +153,8 @@ class AddScheduleViewModel
                         description = event.schedule.description,
                         selectedTime = event.startTime,
                         endTime = event.endTime,
+                        startTimeInput = ScheduleTimeInput.from(event.startTime),
+                        endTimeInput = ScheduleTimeInput.from(event.endTime),
                         recurring = event.schedule.recurring,
                         recurringType = event.schedule.recurringType ?: "daily",
                         isLoading = false,
@@ -140,29 +184,39 @@ class AddScheduleViewModel
             }
 
         private fun loadForEdit(scheduleId: String) {
-            dispatch(AddScheduleReducerEvent.EditLoading)
-            viewModelScope.launch {
-                when (val result = scheduleRepository.getScheduleById(scheduleId)) {
-                    is ScheduleRepository.ScheduleResult.Success -> {
-                        val schedule = result.data
-                        dispatch(
-                            AddScheduleReducerEvent.EditLoaded(
-                                schedule = schedule,
-                                startTime = Calendar.getInstance().apply { time = schedule.startTime.toDate() },
-                                endTime = schedule.endTime?.let { end -> Calendar.getInstance().apply { time = end.toDate() } },
-                            ),
-                        )
-                    }
+            if (currentState.editingSchedule?.id == scheduleId ||
+                (currentState.editScheduleId == scheduleId && editLoadJob?.isActive == true)
+            ) {
+                return
+            }
+            editLoadJob?.cancel()
+            dispatch(AddScheduleReducerEvent.EditLoading(scheduleId))
+            editLoadJob =
+                viewModelScope.launch {
+                    val result = scheduleRepository.getScheduleById(scheduleId)
+                    if (!isActive || currentState.editScheduleId != scheduleId) return@launch
+                    when (result) {
+                        is ScheduleRepository.ScheduleResult.Success -> {
+                            val schedule = result.data
+                            dispatch(
+                                AddScheduleReducerEvent.EditLoaded(
+                                    schedule = schedule,
+                                    startTime = Calendar.getInstance().apply { time = schedule.startTime.toDate() },
+                                    endTime = schedule.endTime?.let { end -> Calendar.getInstance().apply { time = end.toDate() } },
+                                ),
+                            )
+                        }
 
-                    is ScheduleRepository.ScheduleResult.Error -> {
-                        dispatch(AddScheduleReducerEvent.Failed(result.error, canRetry = false))
+                        is ScheduleRepository.ScheduleResult.Error -> {
+                            dispatch(AddScheduleReducerEvent.Failed(result.error, canRetry = true))
+                        }
                     }
                 }
-            }
         }
 
         private fun save() {
             val state = currentState
+            if (state.isLoading || state.isSaved) return
             val title = state.title.trim()
             validationError(state, title)?.let { message ->
                 dispatch(AddScheduleReducerEvent.Failed(AppError.GeneralError(message), canRetry = false))
@@ -199,6 +253,14 @@ class AddScheduleViewModel
             title: String,
         ): String? =
             when {
+                state.isEditMode && state.editingSchedule == null -> {
+                    "수정할 일정을 먼저 불러와 주세요"
+                }
+
+                !state.hasValidTimeInput -> {
+                    "시간을 확인해 주세요 (시 0~23, 분 0~59)"
+                }
+
                 title.isBlank() -> {
                     "할 일을 입력해주세요"
                 }
@@ -217,7 +279,7 @@ class AddScheduleViewModel
             }
 
         private fun AddScheduleUiState.toSchedule(title: String): Schedule {
-            val base = if (isEditMode) editingSchedule ?: Schedule() else Schedule()
+            val base = if (isEditMode) requireNotNull(editingSchedule) else Schedule()
             return base.copy(
                 title = title,
                 description = description.trim(),

--- a/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/components/TimePickerSection.kt
+++ b/feature/addschedule/src/main/java/com/example/slowclock/ui/addschedule/components/TimePickerSection.kt
@@ -21,36 +21,21 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Locale
+import com.example.slowclock.ui.addschedule.ScheduleTimeInput
 
 @Composable
 fun TimePickerSection(
-    selectedTime: Calendar,
-    endTime: Calendar?,
-    onTimeSelect: (Calendar) -> Unit,
-    onEndTimeSelect: (Calendar?) -> Unit,
+    startTime: ScheduleTimeInput,
+    endTime: ScheduleTimeInput,
+    onTimeSelect: (ScheduleTimeInput) -> Unit,
+    onEndTimeSelect: (ScheduleTimeInput) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val timeFormat = SimpleDateFormat("a h:mm", Locale.KOREAN)
-
-    // 입력값을 기억할 상태
-    var hour by remember { mutableStateOf(selectedTime.get(Calendar.HOUR_OF_DAY).toString()) }
-    var minute by remember { mutableStateOf(selectedTime.get(Calendar.MINUTE).toString()) }
-
-    var endHour by remember { mutableStateOf(endTime?.get(Calendar.HOUR_OF_DAY)?.toString() ?: "") }
-    var endMinute by remember { mutableStateOf(endTime?.get(Calendar.MINUTE)?.toString() ?: "") }
-
     Column(
         modifier =
             modifier
@@ -77,10 +62,9 @@ fun TimePickerSection(
 
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     OutlinedTextField(
-                        value = hour,
+                        value = startTime.hour,
                         onValueChange = {
-                            hour = it.filter { c -> c.isDigit() }.take(2)
-                            updateCalendarTime(hour, minute)?.let(onTimeSelect)
+                            onTimeSelect(startTime.copy(hour = it.filter { c -> c.isDigit() }.take(2)))
                         },
                         label = { Text("시") },
                         modifier = Modifier.weight(1f),
@@ -90,10 +74,9 @@ fun TimePickerSection(
                     )
 
                     OutlinedTextField(
-                        value = minute,
+                        value = startTime.minute,
                         onValueChange = {
-                            minute = it.filter { c -> c.isDigit() }.take(2)
-                            updateCalendarTime(hour, minute)?.let(onTimeSelect)
+                            onTimeSelect(startTime.copy(minute = it.filter { c -> c.isDigit() }.take(2)))
                         },
                         label = { Text("분") },
                         modifier = Modifier.weight(1f),
@@ -122,10 +105,9 @@ fun TimePickerSection(
 
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     OutlinedTextField(
-                        value = endHour,
+                        value = endTime.hour,
                         onValueChange = {
-                            endHour = it.filter { c -> c.isDigit() }.take(2)
-                            updateCalendarTime(endHour, endMinute)?.let(onEndTimeSelect)
+                            onEndTimeSelect(endTime.copy(hour = it.filter { c -> c.isDigit() }.take(2)))
                         },
                         label = { Text("시") },
                         modifier = Modifier.weight(1f),
@@ -135,10 +117,9 @@ fun TimePickerSection(
                     )
 
                     OutlinedTextField(
-                        value = endMinute,
+                        value = endTime.minute,
                         onValueChange = {
-                            endMinute = it.filter { c -> c.isDigit() }.take(2)
-                            updateCalendarTime(endHour, endMinute)?.let(onEndTimeSelect)
+                            onEndTimeSelect(endTime.copy(minute = it.filter { c -> c.isDigit() }.take(2)))
                         },
                         label = { Text("분") },
                         modifier = Modifier.weight(1f),
@@ -151,23 +132,3 @@ fun TimePickerSection(
         }
     }
 }
-
-fun updateCalendarTime(
-    hour: String,
-    minute: String,
-): Calendar? =
-    try {
-        val h = hour.toInt()
-        val m = minute.toInt()
-        if (h in 0..23 && m in 0..59) {
-            Calendar.getInstance().apply {
-                set(Calendar.HOUR_OF_DAY, h)
-                set(Calendar.MINUTE, m)
-                set(Calendar.SECOND, 0)
-            }
-        } else {
-            null
-        }
-    } catch (e: NumberFormatException) {
-        null
-    }

--- a/feature/addschedule/src/test/java/com/example/slowclock/ui/addschedule/AddScheduleEditTest.kt
+++ b/feature/addschedule/src/test/java/com/example/slowclock/ui/addschedule/AddScheduleEditTest.kt
@@ -1,0 +1,318 @@
+package com.example.slowclock.ui.addschedule
+
+import com.example.slowclock.core.alarm.AlarmScheduler
+import com.example.slowclock.data.model.Schedule
+import com.example.slowclock.data.remote.repository.ScheduleRepository
+import com.example.slowclock.data.remote.repository.ScheduleRepository.ScheduleResult
+import com.example.slowclock.util.AppError
+import com.google.firebase.Timestamp
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Calendar
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddScheduleEditTest {
+    private val repository = mockk<ScheduleRepository>()
+    private val alarms = mockk<AlarmScheduler>(relaxed = true)
+    private val start = date(2032, Calendar.JANUARY, 5, 22, 10)
+    private val end = date(2032, Calendar.JANUARY, 6, 1, 20)
+    private val existing = Schedule("s1", title = "기존 일정", startTime = Timestamp(start.time), endTime = Timestamp(end.time))
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun loadedViewModel(): AddScheduleViewModel {
+        coEvery { repository.getScheduleById("s1") } returns ScheduleResult.Success(existing)
+        return AddScheduleViewModel(repository, alarms).also { it.onIntent(AddScheduleIntent.LoadForEdit("s1")) }
+    }
+
+    @Test
+    fun `늦게 불러온 편집 시각이 입력칸 상태에도 반영된다`() =
+        runTest {
+            val pending = CompletableDeferred<ScheduleResult<Schedule>>()
+            coEvery { repository.getScheduleById("s1") } coAnswers { pending.await() }
+            val viewModel = AddScheduleViewModel(repository, alarms)
+
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+            assertFalse(viewModel.uiState.value.canSave)
+            pending.complete(ScheduleResult.Success(existing))
+
+            val state = viewModel.uiState.value
+            assertEquals(ScheduleTimeInput("22", "10"), state.startTimeInput)
+            assertEquals(ScheduleTimeInput("1", "20"), state.endTimeInput)
+            assertEquals(start.timeInMillis, state.selectedTime.timeInMillis)
+            assertEquals(end.timeInMillis, state.endTime?.timeInMillis)
+            assertTrue(state.canSave)
+        }
+
+    @Test
+    fun `조회 중 같은 ID 재진입은 중복 요청을 보내지 않는다`() =
+        runTest {
+            val pending = CompletableDeferred<ScheduleResult<Schedule>>()
+            coEvery { repository.getScheduleById("s1") } coAnswers { pending.await() }
+            val viewModel = AddScheduleViewModel(repository, alarms)
+
+            repeat(2) { viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1")) }
+            pending.complete(ScheduleResult.Success(existing))
+
+            coVerify(exactly = 1) { repository.getScheduleById("s1") }
+        }
+
+    @Test
+    fun `조회가 끝난 같은 ID 재진입은 입력 중인 제목과 시간을 덮지 않는다`() =
+        runTest {
+            val viewModel = loadedViewModel()
+            val input = ScheduleTimeInput("23", "")
+            viewModel.onIntent(AddScheduleIntent.UpdateTitle("작성 중인 제목"))
+            viewModel.onIntent(AddScheduleIntent.UpdateTimeInput(input))
+
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+
+            assertEquals("작성 중인 제목", viewModel.uiState.value.title)
+            assertEquals(input, viewModel.uiState.value.startTimeInput)
+            coVerify(exactly = 1) { repository.getScheduleById("s1") }
+        }
+
+    @Test
+    fun `다른 ID를 불러온 뒤 먼저 요청한 일정의 늦은 성공은 무시한다`() =
+        runTest {
+            val pending = CompletableDeferred<ScheduleResult<Schedule>>()
+            coEvery { repository.getScheduleById("s1") } coAnswers { withContext(NonCancellable) { pending.await() } }
+            val other = existing.copy(id = "s2", title = "다른 일정")
+            coEvery { repository.getScheduleById("s2") } returns ScheduleResult.Success(other)
+            val viewModel = AddScheduleViewModel(repository, alarms)
+
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s2"))
+            pending.complete(ScheduleResult.Success(existing))
+
+            assertEquals(
+                "s2",
+                viewModel.uiState.value.editingSchedule
+                    ?.id,
+            )
+            assertEquals("다른 일정", viewModel.uiState.value.title)
+            assertNull(viewModel.uiState.value.error)
+        }
+
+    @Test
+    fun `다른 ID를 불러온 뒤 먼저 요청한 일정의 늦은 실패는 무시한다`() =
+        runTest {
+            val pending = CompletableDeferred<ScheduleResult<Schedule>>()
+            coEvery { repository.getScheduleById("s1") } coAnswers { withContext(NonCancellable) { pending.await() } }
+            coEvery { repository.getScheduleById("s2") } returns ScheduleResult.Success(existing.copy(id = "s2"))
+            val viewModel = AddScheduleViewModel(repository, alarms)
+
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s2"))
+            pending.complete(ScheduleResult.Error(AppError.NetworkError))
+
+            assertEquals(
+                "s2",
+                viewModel.uiState.value.editingSchedule
+                    ?.id,
+            )
+            assertNull(viewModel.uiState.value.error)
+            assertTrue(viewModel.uiState.value.canSave)
+        }
+
+    @Test
+    fun `편집 조회 실패의 재시도는 새 일정을 저장하지 않고 다시 읽는다`() =
+        runTest {
+            coEvery { repository.getScheduleById("s1") } returns ScheduleResult.Error(AppError.NetworkError) andThen
+                ScheduleResult.Success(existing)
+            val viewModel = AddScheduleViewModel(repository, alarms)
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+            assertTrue(viewModel.uiState.value.canRetry)
+            assertFalse(viewModel.uiState.value.canSave)
+
+            viewModel.onIntent(AddScheduleIntent.Retry)
+
+            assertEquals(existing, viewModel.uiState.value.editingSchedule)
+            assertNull(viewModel.uiState.value.error)
+            coVerify(exactly = 2) { repository.getScheduleById("s1") }
+            coVerify(exactly = 0) { repository.addSchedule(any()) }
+            coVerify(exactly = 0) { repository.updateSchedule(any()) }
+        }
+
+    @Test
+    fun `편집 추천 제목은 초기 조회가 성공한 뒤에만 받을 수 있다`() =
+        runTest {
+            val pending = CompletableDeferred<ScheduleResult<Schedule>>()
+            coEvery { repository.getScheduleById("s1") } coAnswers { pending.await() }
+            val viewModel = AddScheduleViewModel(repository, alarms)
+            assertFalse(viewModel.uiState.value.canApplyRecommendedTitle("s1"))
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+            assertFalse(viewModel.uiState.value.canApplyRecommendedTitle("s1"))
+
+            pending.complete(ScheduleResult.Success(existing))
+
+            assertTrue(viewModel.uiState.value.canApplyRecommendedTitle("s1"))
+            assertFalse(viewModel.uiState.value.canApplyRecommendedTitle("s2"))
+            viewModel.onIntent(AddScheduleIntent.UpdateTitle("추천 제목"))
+            viewModel.onIntent(AddScheduleIntent.UpdateTitle("직접 고친 제목"))
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+            assertEquals("직접 고친 제목", viewModel.uiState.value.title)
+        }
+
+    @Test
+    fun `편집 조회가 실패하면 추천 결과는 재시도가 성공할 때까지 기다린다`() =
+        runTest {
+            coEvery { repository.getScheduleById("s1") } returns ScheduleResult.Error(AppError.NetworkError) andThen
+                ScheduleResult.Success(existing)
+            val viewModel = AddScheduleViewModel(repository, alarms)
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+            assertFalse(viewModel.uiState.value.canApplyRecommendedTitle("s1"))
+
+            viewModel.onIntent(AddScheduleIntent.Retry)
+
+            assertTrue(viewModel.uiState.value.canApplyRecommendedTitle("s1"))
+        }
+
+    @Test
+    fun `편집 조회가 실패한 상태에서 저장을 눌러도 빈 일정이 추가되지 않는다`() =
+        runTest {
+            coEvery { repository.getScheduleById("s1") } returns ScheduleResult.Error(AppError.NetworkError)
+            val viewModel = AddScheduleViewModel(repository, alarms)
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s1"))
+            viewModel.onIntent(AddScheduleIntent.UpdateTitle("제목"))
+
+            viewModel.onIntent(AddScheduleIntent.Save)
+
+            coVerify(exactly = 0) { repository.addSchedule(any()) }
+            coVerify(exactly = 0) { repository.updateSchedule(any()) }
+        }
+
+    @Test
+    fun `시작 시간의 잘못된 입력은 화면과 저장 동작에서 함께 막는다`() =
+        runTest {
+            val viewModel = loadedViewModel()
+            listOf(ScheduleTimeInput("", "10"), ScheduleTimeInput("24", "10"), ScheduleTimeInput("22", "60")).forEach { input ->
+                viewModel.onIntent(AddScheduleIntent.UpdateTimeInput(input))
+                assertEquals(input, viewModel.uiState.value.startTimeInput)
+                assertFalse(viewModel.uiState.value.canSave)
+                viewModel.onIntent(AddScheduleIntent.Save)
+            }
+
+            coVerify(exactly = 0) { repository.updateSchedule(any()) }
+        }
+
+    @Test
+    fun `시간을 편집해도 시작 날짜와 자정을 넘은 종료 날짜는 보존한다`() =
+        runTest {
+            val updated = slot<Schedule>()
+            coEvery { repository.updateSchedule(capture(updated)) } returns ScheduleResult.Success(Unit)
+            val viewModel = loadedViewModel()
+
+            viewModel.onIntent(AddScheduleIntent.UpdateTimeInput(ScheduleTimeInput("23", "30")))
+            viewModel.onIntent(AddScheduleIntent.UpdateTimeInput(ScheduleTimeInput("2", "40"), isEnd = true))
+            viewModel.onIntent(AddScheduleIntent.Save)
+
+            assertEquals(
+                date(2032, Calendar.JANUARY, 5, 23, 30).timeInMillis,
+                updated.captured.startTime
+                    .toDate()
+                    .time,
+            )
+            assertEquals(
+                date(2032, Calendar.JANUARY, 6, 2, 40).timeInMillis,
+                updated.captured.endTime
+                    ?.toDate()
+                    ?.time,
+            )
+            assertEquals(start.timeInMillis, existing.startTime.toDate().time)
+        }
+
+    @Test
+    fun `종료 시간의 일부 빈칸은 저장을 막고 모두 비우면 종료를 제거한다`() =
+        runTest {
+            val updated = slot<Schedule>()
+            coEvery { repository.updateSchedule(capture(updated)) } returns ScheduleResult.Success(Unit)
+            val viewModel = loadedViewModel()
+            viewModel.onIntent(AddScheduleIntent.UpdateTimeInput(ScheduleTimeInput("", "20"), isEnd = true))
+            assertFalse(viewModel.uiState.value.canSave)
+            viewModel.onIntent(AddScheduleIntent.Save)
+            coVerify(exactly = 0) { repository.updateSchedule(any()) }
+
+            viewModel.onIntent(AddScheduleIntent.UpdateTimeInput(ScheduleTimeInput(), isEnd = true))
+            assertTrue(viewModel.uiState.value.canSave)
+            assertNull(viewModel.uiState.value.endTime)
+            viewModel.onIntent(AddScheduleIntent.Save)
+
+            assertNull(updated.captured.endTime)
+        }
+
+    @Test
+    fun `저장 중과 완료 신호가 남은 동안 다시 눌러도 한 번만 저장한다`() =
+        runTest {
+            val pending = CompletableDeferred<ScheduleResult<Unit>>()
+            coEvery { repository.updateSchedule(any()) } coAnswers { pending.await() }
+            val viewModel = loadedViewModel()
+
+            repeat(2) { viewModel.onIntent(AddScheduleIntent.Save) }
+            viewModel.onIntent(AddScheduleIntent.Retry)
+            pending.complete(ScheduleResult.Success(Unit))
+            viewModel.onIntent(AddScheduleIntent.Save)
+
+            coVerify(exactly = 1) { repository.updateSchedule(any()) }
+            assertTrue(viewModel.uiState.value.isSaved)
+        }
+
+    @Test
+    fun `저장 중 다른 일정 조회가 현재 저장 결과의 대상을 바꾸지 않는다`() =
+        runTest {
+            val pending = CompletableDeferred<ScheduleResult<Unit>>()
+            coEvery { repository.updateSchedule(any()) } coAnswers { pending.await() }
+            coEvery { repository.getScheduleById("s2") } returns ScheduleResult.Success(existing.copy(id = "s2"))
+            val viewModel = loadedViewModel()
+            viewModel.onIntent(AddScheduleIntent.Save)
+
+            viewModel.onIntent(AddScheduleIntent.LoadForEdit("s2"))
+            pending.complete(ScheduleResult.Success(Unit))
+
+            coVerify(exactly = 0) { repository.getScheduleById("s2") }
+            assertEquals(
+                "s1",
+                viewModel.uiState.value.editingSchedule
+                    ?.id,
+            )
+            assertTrue(viewModel.uiState.value.isSaved)
+        }
+
+    private fun date(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int,
+    ): Calendar =
+        Calendar.getInstance().apply {
+            clear()
+            set(year, month, day, hour, minute)
+        }
+}

--- a/feature/addschedule/src/test/java/com/example/slowclock/ui/addschedule/ScheduleTimeInputTest.kt
+++ b/feature/addschedule/src/test/java/com/example/slowclock/ui/addschedule/ScheduleTimeInputTest.kt
@@ -1,0 +1,59 @@
+package com.example.slowclock.ui.addschedule
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Calendar
+import java.util.TimeZone
+
+class ScheduleTimeInputTest {
+    @Test
+    fun `하루의 경계 시각과 앞자리 영은 유효하다`() {
+        listOf(ScheduleTimeInput("0", "0"), ScheduleTimeInput("23", "59"), ScheduleTimeInput("09", "05")).forEach {
+            assertTrue(it.isValid)
+        }
+    }
+
+    @Test
+    fun `빈칸과 범위 밖 값은 날짜로 바꾸지 않는다`() {
+        listOf(
+            ScheduleTimeInput(),
+            ScheduleTimeInput("12", ""),
+            ScheduleTimeInput("", "30"),
+            ScheduleTimeInput("24", "0"),
+            ScheduleTimeInput("12", "60"),
+            ScheduleTimeInput("-1", "0"),
+            ScheduleTimeInput("abc", "30"),
+        ).forEach {
+            assertFalse(it.isValid)
+            assertNull(it.onDate(Calendar.getInstance()))
+        }
+    }
+
+    @Test
+    fun `시간 변환은 원래 날짜와 시간대를 유지하고 원본을 변경하지 않는다`() {
+        val date =
+            Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+                clear()
+                set(2032, Calendar.FEBRUARY, 29, 8, 15, 37)
+                set(Calendar.MILLISECOND, 125)
+            }
+        val original = date.timeInMillis
+
+        val result = ScheduleTimeInput("23", "59").onDate(date)!!
+
+        assertNotSame(date, result)
+        assertEquals(original, date.timeInMillis)
+        assertEquals(date.timeZone, result.timeZone)
+        assertEquals(2032, result.get(Calendar.YEAR))
+        assertEquals(Calendar.FEBRUARY, result.get(Calendar.MONTH))
+        assertEquals(29, result.get(Calendar.DAY_OF_MONTH))
+        assertEquals(23, result.get(Calendar.HOUR_OF_DAY))
+        assertEquals(59, result.get(Calendar.MINUTE))
+        assertEquals(0, result.get(Calendar.SECOND))
+        assertEquals(0, result.get(Calendar.MILLISECOND))
+    }
+}


### PR DESCRIPTION
## 📌 Issues
- closed #186

## 📎 Work Description
- 잘못 입력한 시간은 그대로 보여 주고 저장을 막으며, 종료 시간을 지우면 삭제한 상태로 저장합니다.
- 편집 데이터를 중복으로 불러와 입력을 덮어쓰지 않고, 불러오기 실패의 재시도와 저장을 구분합니다.
- 추천 제목을 선택한 편집 화면에 한 번만 전달하고, 완료 기록과 공유 코드의 최신 값을 보존합니다.

## 📷 Screenshot
- 입력 오류가 보이도록 스크롤하고 중첩 화면의 시스템 인셋을 소비하도록 보완했습니다. 기존 Compose screenshot 검증을 실행합니다.

## 💬 To Reviewers
- 신규 회귀 테스트 25개를 포함해 일정 입력·저장·추천 전달을 검증했습니다.
- 최신 main의 알람 및 Firestore 변경을 통합한 뒤 app/core:data/feature:addschedule 단위 테스트와 app Kotlin 컴파일을 통과했습니다.
- 관련 세 모듈의 ktlint를 통과했습니다.
