### PR TITLE
docs: 건강 선언과 의존성 검증 범위 정정

### DIFF
--- a/docs/play-release.md
+++ b/docs/play-release.md
@@ -25,7 +25,7 @@ Firebase App Distribution 과 Google Play 의 목적을 분리하고, 첫 Play �
 - `applicationId` 는 `com.ilhyok.slowclock`. Firebase Android 앱과 `google-services.json` 도 이 패키지로 등록돼 있다.
 - Google 로그인 스코프는 `userinfo.profile`·`userinfo.email` 뿐이다. 민감 스코프(Calendar)를 빼서 OAuth 검증 심사 대상이 아니다.
 - 서비스 계정 키를 APK 에 내장하던 Vertex AI 경로는 제거됐다.
-- 개인정보처리방침·이용약관: `https://1hyok.github.io/SlowClock/privacy.html` · `https://1hyok.github.io/SlowClock/terms.html` (저장소 `docs/`, GitHub Pages). Play 콘솔 앱 콘텐츠의 개인정보처리방침 URL 에 같은 주소를 쓴다.
+- 개인정보처리방침·이용약관: `https://1hyok.me/SlowClock/privacy.html` · `https://1hyok.me/SlowClock/terms.html` (저장소 `docs/`, GitHub Pages). Play 콘솔 앱 콘텐츠의 개인정보처리방침 URL 에 같은 주소를 쓴다.
 - 광고 ID 권한(`AD_ID`·`ACCESS_ADSERVICES_*`)은 manifest 에서 제거했다. 데이터 보안 양식에서 광고 ID 수집은 「아니오」다.
 - 권한 선언 양식: `USE_EXACT_ALARM`(알람이 본업인 앱에 자동 부여, #122), `SCHEDULE_EXACT_ALARM`(`maxSdkVersion="32"` — API 32 기기 전용), `USE_FULL_SCREEN_INTENT`(알람 전체 화면), `RECEIVE_BOOT_COMPLETED`(재부팅 뒤 알람 복원, #127), `FOREGROUND_SERVICE_MEDIA_PLAYBACK`(알람 소리 재생). 포그라운드 서비스는 `AlarmTriggerService` 하나이고 유형은 `mediaPlayback` 이다 — `shortService` 는 시간 제한이 있고 배경 오디오의 문턱 아래라 알람 소리를 이어 가지 못해 #122 에서 바꿨다. 이 유형은 콘솔 선언 대상이다(아래 표의 「포그라운드 서비스」 행). 상시 알림을 띄우던 `dataSync` 서비스는 #47 에서 제거했다.
 - release 빌드는 R8 과 리소스 축소를 켠다(`isMinifyEnabled = true`, `isShrinkResources = true`, #113). Firestore 가 이름으로 읽는 모델, kotlinx.serialization 이 만드는 serializer, Navigation 3 의 화면 키는 `app/proguard-rules.pro` 가 남긴다. Crashlytics 매핑 업로드도 함께 켜져 있어 난독화된 스택을 되돌릴 수 있다. [preflight 리포트](../.github/scripts/render-release-aab-report.mjs) 가 mapping 유무를 그대로 보고한다.
@@ -49,6 +49,8 @@ JAVA_HOME=~/Library/Java/JavaVirtualMachines/temurin-21.0.11/Contents/Home \
 
 2026-09-06 확인(의존성 파일 기준 `3eea3ec`): 열린 54건(high 19 · moderate 29 · low 6)의 해당 취약 버전은 Android release runtime에서 확인되지 않았다. 다만 high 19건은 Netty·jose4j·JDOM의 빌드/테스트 경로에 남고, Cloud Functions의 `qs`·`uuid`는 서버 런타임에 남는다. Guava도 runtime `32.1.3-android`와 달리 compile 구성은 `31.1-android`이므로 경로별로 판정해야 한다. 이는 해당 경보 집합에 대한 확인이며 전체 산출물의 안전성을 보증하지 않는다.
 
+PR #199에서 Functions의 `qs`를 `6.16.0`으로 제한 업데이트하고 Node 22의 실제 handler·Express 파싱 검증을 통과했다. 2026-09-06 후속 조회의 열린 경보는 52건(high 19 · moderate 27 · low 6)이었다. 이는 저장소 변경 후 경보 집계이며 운영 Functions 배포 완료를 뜻하지 않는다. `uuid`와 빌드·테스트 도구 경보는 남아 있다. `qs` 수정 근거: [공식 배열 제한 권고](https://github.com/ljharb/qs/security/advisories/GHSA-x5fp-wj9c-mxmx), [공식 isBuffer 권고](https://github.com/ljharb/qs/security/advisories/GHSA-4mjr-xmp4-gh2g).
+
 수정은 상위 라이브러리의 지원 버전을 우선 확인한다. 전이 의존성을 강제로 바꿀 때는 해당 구성의 실제 실행 검증이 필요하다. 최신 상위 버전에도 남는 경보는 상위 수정 추적 대상으로 기록하며 무조건 dismiss하지 않는다.
 
 `dependency-review`는 PR이 바꾸는 의존성만 본다. 기존 경보나 런타임 도달성은 이 검사만으로 판정할 수 없다. 주간 감사의 루트 build/debug runtime 보고만으로 앱 build classpath·compile·UTP·ktlint 구성 전체를 확인했다고 판단하지 않는다.
@@ -69,7 +71,7 @@ JAVA_HOME=~/Library/Java/JavaVirtualMachines/temurin-21.0.11/Contents/Home \
 | 뉴스 앱 | 아니오 | 정보 탭은 메디컬타임즈로 이동하는 버튼 하나뿐이고 기사를 앱 안에 표시하지 않는다(#51) |
 | 정부 앱 | 아니오 | |
 | 금융 기능 | 없음 | |
-| 건강 | 해당 없음. 의료 기기·건강 데이터·건강 기록 기능이 없고, 건강 관련 콘텐츠도 앱 안에 없다 | 외부 사이트로 나가는 링크뿐(#51 에서 스크래핑 제거) |
+| 건강 | 제출 전 범주 확인 필요. 현재 기능을 그대로 출시하면서 「건강 기능 없음」으로 단정하지 않는다 | 앱 안에 ADHD 분류와 감정 일기·회피 행동 돌아보기·명상 일정 추천이 있다. 기사 스크래핑 제거(#51)만으로 이 추천까지 없어지지는 않는다 |
 | 데이터 보안: 수집 | 개인 정보(이름, 이메일 주소, 사용자 ID), 앱 활동(앱 상호작용, 기타 사용자 생성 콘텐츠: 일정·메모), 기기 또는 기타 ID(FCM 토큰, Firebase 설치 ID, Analytics 앱 인스턴스 ID, Crashlytics 설치 식별자), 위치(대략적인 위치: IP 기반), 앱 정보 및 성능(비정상 종료 로그, 진단) | Firebase Auth·Firestore·FCM·Analytics·Crashlytics |
 | 데이터 보안: 공유 | 제3자 공유 없음. Firebase 는 서비스 제공업체. 공유 코드를 통한 열람은 사용자가 시작한 행동 | privacy.html 4절, [firestore.md](firestore.md) 의 컬렉션 표 |
 | 데이터 보안: 처리 | 전송 중 암호화 「예」. 계정 삭제 요청 방법 「예」: 앱 안 내 정보 화면과 `https://1hyok.me/SlowClock/delete-account.html`(#46) | HTTPS, #46 |
@@ -80,6 +82,8 @@ JAVA_HOME=~/Library/Java/JavaVirtualMachines/temurin-21.0.11/Contents/Home \
 | 사진·동영상 권한 | 해당 없음 | 미디어 권한 없음 |
 
 Analytics는 광고 ID 권한을 제거해도 앱 인스턴스 ID와 IP 기반 대략적 위치를 자동 수집한다. 선언 근거는 [Analytics 공식 안내](https://support.google.com/analytics/answer/11582702?hl=en)와 [Firebase SDK별 안내](https://firebase.google.com/docs/android/play-data-disclosure)다. 현재 앱에는 새 그룹 생성 기능이 없고 과거 그룹 기록은 계정 삭제 때 정리한다.
+
+건강 선언은 데이터 수집 여부와 별개로 실제 제공 기능을 본다. [Play 공식 선언 안내](https://support.google.com/googleplay/android-developer/answer/14738291?hl=en)는 명상·인지 건강 안내를 스트레스 관리/이완/정신적 예민함 범주로, 정신 건강 지원 도구를 정신 및 행동 건강 범주로 설명한다. 현재 추천 내용은 이 범주와 대조해야 한다는 판단이며 Google의 심사 결과를 확인한 것은 아니다. 제출 전 실제 추천 화면과 스토어 문구를 함께 보고 해당 범주를 선택하고, 확정 전에는 선언을 초안으로 남긴다. 앱에는 진단·치료·측정 기능이나 Health Connect 연동이 구현되어 있지 않지만 그것만으로 건강 기능 전체가 없다고 판단하지 않는다. [건강 콘텐츠 정책](https://support.google.com/googleplay/android-developer/answer/16679511?hl=en)도 함께 확인한다.
 
 제출 전에 Analytics Console의 보유 기간·Google Signals·광고 계정 연결·데이터 공유 설정을 실제로 확인해 선언과 맞춘다. 저장소만으로 이 설정의 현재 값을 확인한 것으로 취급하지 않는다. 계정 삭제와 별도 설치 식별자의 보유 범위는 개인정보처리방침 및 계정 삭제 안내에 함께 설명한다.
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
Closes #208

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
앱 안의 ADHD 분류와 감정 일기·명상 추천이 남아 있는데 출시 문서가 건강 관련 콘텐츠가 없다고 단정하던 설명을 바로잡습니다. Play 건강 선언은 실제 추천 화면과 스토어 문구를 대조해 제출 전에 확인하도록 적었습니다. 개인정보 안내의 canonical URL과 Functions qs 수정 후 남은 의존성 경보도 현재 증거로 갱신합니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
문서만 변경하여 해당 없음.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
`node .github/scripts/verify-markdown-links.mjs` 성공(12개 문서). `git diff --check` 성공. 운영 Functions 배포나 Play 선언 제출은 수행하지 않았으며, 열린 의존성 경보 52건을 해결했다고 주장하지 않습니다.

근거: [Play 건강 선언 안내](https://support.google.com/googleplay/android-developer/answer/14738291?hl=en), [건강 콘텐츠 정책](https://support.google.com/googleplay/android-developer/answer/16679511?hl=en), [qs 배열 제한 권고](https://github.com/ljharb/qs/security/advisories/GHSA-x5fp-wj9c-mxmx), [qs isBuffer 권고](https://github.com/ljharb/qs/security/advisories/GHSA-4mjr-xmp4-gh2g).
