### PR TITLE
fix: 수동 PR 검증의 숫자 입력 정규화

### DIFF
--- a/.github/scripts/pr-gate-policy.test.mjs
+++ b/.github/scripts/pr-gate-policy.test.mjs
@@ -100,12 +100,12 @@ test("stale runs are cancelled per pull request", async () => {
     );
 });
 
-test("token-authored commits preserve the pull request context on manual dispatch", async () => {
+test("token-authored commits normalize manual dispatch PR numbers for every reusable workflow", async () => {
     const entry = await readWorkflow(ENTRY_WORKFLOW);
 
     assert.match(entry, /^\s{2}workflow_dispatch:\n\s{4}inputs:\n\s{6}pull_request_number:/m);
     assert.equal(
-        (entry.match(/pull_request_number: \$\{\{ inputs\.pull_request_number \|\| github\.event\.pull_request\.number \|\| 0 \}\}/g) ?? []).length,
+        (entry.match(/pull_request_number: \$\{\{ fromJSON\(format\('\{0\}', inputs\.pull_request_number \|\| github\.event\.pull_request\.number \|\| 0\)\) \}\}/g) ?? []).length,
         VALIDATION_WORKFLOWS.length,
     );
 });
@@ -118,7 +118,7 @@ test("validation without a pull request number falls back to the full suite", as
     const repositoryQuality = await readWorkflow("repository-quality.yml");
 
     assert.equal(
-        (entry.match(/\|\| github\.event\.pull_request\.number \|\| 0 \}\}/g) ?? []).length,
+        (entry.match(/\|\| github\.event\.pull_request\.number \|\| 0\)\) \}\}/g) ?? []).length,
         VALIDATION_WORKFLOWS.length,
     );
     for (const gate of ["Require linked Issue"]) {

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -33,12 +33,15 @@ permissions:
   issues: read
   pull-requests: write
 
+# API dispatch로 받은 번호는 문자열일 수 있다. reusable workflow의 number 계약에
+# 맞춰 명시적으로 변환한다. PR 이벤트의 숫자와 번호 없는 경우의 0도 같은 경로를 쓴다.
+# https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#fromjson
 jobs:
   repository-quality:
     name: Repository Quality
     uses: ./.github/workflows/repository-quality.yml
     with:
-      pull_request_number: ${{ inputs.pull_request_number || github.event.pull_request.number || 0 }}
+      pull_request_number: ${{ fromJSON(format('{0}', inputs.pull_request_number || github.event.pull_request.number || 0)) }}
 
   static-analysis:
     name: Static Analysis
@@ -46,7 +49,7 @@ jobs:
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/lint.yml
     with:
-      pull_request_number: ${{ inputs.pull_request_number || github.event.pull_request.number || 0 }}
+      pull_request_number: ${{ fromJSON(format('{0}', inputs.pull_request_number || github.event.pull_request.number || 0)) }}
       run_ktlint: ${{ needs.repository-quality.result != 'success' || needs.repository-quality.outputs.ktlint_required != 'false' }}
       ktlint_tasks: ${{ needs.repository-quality.result == 'success' && needs.repository-quality.outputs.ktlint_tasks || 'ktlintCheck' }}
       run_android_lint: ${{ needs.repository-quality.result != 'success' || needs.repository-quality.outputs.android_lint_required != 'false' }}
@@ -59,7 +62,7 @@ jobs:
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/unit-test.yml
     with:
-      pull_request_number: ${{ inputs.pull_request_number || github.event.pull_request.number || 0 }}
+      pull_request_number: ${{ fromJSON(format('{0}', inputs.pull_request_number || github.event.pull_request.number || 0)) }}
       run_validation: ${{ needs.repository-quality.result != 'success' || needs.repository-quality.outputs.unit_test_required != 'false' }}
       run_node_tests: ${{ needs.repository-quality.result != 'success' || needs.repository-quality.outputs.run_node_tests != 'false' }}
       gradle_tasks: ${{ needs.repository-quality.result == 'success' && needs.repository-quality.outputs.unit_test_tasks || 'testDebugUnitTest :app:compileDebugAndroidTestKotlin' }}
@@ -70,7 +73,7 @@ jobs:
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/screenshot.yml
     with:
-      pull_request_number: ${{ inputs.pull_request_number || github.event.pull_request.number || 0 }}
+      pull_request_number: ${{ fromJSON(format('{0}', inputs.pull_request_number || github.event.pull_request.number || 0)) }}
       run_validation: ${{ needs.repository-quality.result != 'success' || needs.repository-quality.outputs.screenshot_required != 'false' }}
       gradle_tasks: ${{ needs.repository-quality.result == 'success' && needs.repository-quality.outputs.screenshot_tasks || ':app:validateScreenshotTest' }}
       screenshot_modules: ${{ needs.repository-quality.result == 'success' && needs.repository-quality.outputs.screenshot_modules || ':app' }}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
Closes #210

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
스크린샷 bot commit 뒤 수동 재검증이 PR 번호 문자열을 reusable workflow의 number 입력으로 넘기면서 작업 시작 전에 실패했습니다. PR Validation 진입점에서 번호를 명시적으로 숫자로 변환해 네 검증 workflow에 전달합니다. 기존 PR 이벤트와 번호0의 전체 검사 경로는 유지합니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
UI 변경 없음.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
Node 정책 테스트300개, actionlint, git diff --check 성공. 동일 head의 실제 [workflow_dispatch 실행34022399408](https://github.com/1hyok/SlowClock/actions/runs/34022399408)에서 Repository Quality, ktlint, Android lint, unit, screenshot이 모두 성공했습니다. 처음 pull_request 실행은 수동 실행과 같은 PR concurrency에 의해 취소되어, 이 기록을 갱신한 후 정상 PR 이벤트 검사도 확인합니다. 기존 실패 근거는 PR207의 실행34022151411이며 제품 코드 실패와 구분했습니다.

공식 타입 변환 근거: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#fromjson
