### PR TITLE
로그인 중 자동 알림 권한 요청을 없앤다

### DIFF
--- a/app/src/main/java/com/example/slowclock/MainActivity.kt
+++ b/app/src/main/java/com/example/slowclock/MainActivity.kt
@@ -3,10 +3,8 @@ package com.example.slowclock
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
-import android.content.pm.PackageManager
 import android.media.AudioAttributes
 import android.media.RingtoneManager
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -14,7 +12,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.getValue
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -136,7 +133,7 @@ class MainActivity : ComponentActivity() {
         } catch (e: Exception) {
             Log.e("MAIN", "onCreate 실패", e)
         }
-        requestNotificationPermission()
+        // 알림은 메인의 설명을 읽고 설정 버튼을 누른 뒤 허용한다. 로그인 위로 권한창을 띄우지 않는다.
         // 정확한 알람 권한은 메인 화면이 이유를 설명한 뒤 사용자가 원할 때 요청한다(#83).
         createNotificationChannel() // ← 반드시 호출 필요
     }
@@ -164,21 +161,6 @@ class MainActivity : ComponentActivity() {
         val notificationManager: NotificationManager =
             getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
-    }
-
-    // POST_NOTIFICATIONS 는 API 33 에 생겼다. minSdk 32 기기는 설치 시점에 알림 권한을 갖는다.
-    private fun requestNotificationPermission() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
-        if (ContextCompat.checkSelfPermission(
-                this,
-                android.Manifest.permission.POST_NOTIFICATIONS,
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
-            requestPermissions(
-                arrayOf(android.Manifest.permission.POST_NOTIFICATIONS),
-                1001,
-            )
-        }
     }
 
     private fun saveFcmTokenToFirestore() {

--- a/feature/main/src/test/java/com/example/slowclock/ui/main/MainViewModelTest.kt
+++ b/feature/main/src/test/java/com/example/slowclock/ui/main/MainViewModelTest.kt
@@ -87,6 +87,41 @@ class MainViewModelTest {
             every { alarmScheduler.canShowAlarmControls() } returns true
             viewModel.onIntent(MainIntent.ScreenResumed)
             assertTrue(viewModel.uiState.value.alarmControlsAvailable)
+            assertNull(viewModel.uiState.value.openNotificationSettings)
+        }
+
+    @Test
+    fun `알림 차단 상태로 로그인하고 복귀해도 설정을 자동으로 열지 않는다`() =
+        runTest {
+            val uid = MutableStateFlow<String?>(null)
+            every { authRepository.currentUid } answers { uid.value }
+            every { authRepository.observeCurrentUid() } returns uid
+            every { alarmScheduler.canShowAlarmControls() } returns false
+            val viewModel = createViewModel()
+            assertNull(viewModel.uiState.value.openNotificationSettings)
+
+            uid.value = "uid-1"
+            viewModel.onIntent(MainIntent.ScreenResumed)
+
+            assertFalse(viewModel.uiState.value.alarmControlsAvailable)
+            assertNull(viewModel.uiState.value.openNotificationSettings)
+        }
+
+    @Test
+    fun `알림을 허용하지 않고 설정에서 돌아오면 안내를 유지하고 다시 누를 수 있다`() =
+        runTest {
+            every { alarmScheduler.canShowAlarmControls() } returns false
+            val viewModel = createViewModel()
+            viewModel.onIntent(MainIntent.OpenNotificationSettings)
+            assertNotNull(viewModel.uiState.value.openNotificationSettings)
+            viewModel.onIntent(MainIntent.ConsumeNotificationSettingsRequest)
+
+            viewModel.onIntent(MainIntent.ScreenResumed)
+
+            assertFalse(viewModel.uiState.value.alarmControlsAvailable)
+            assertNull(viewModel.uiState.value.openNotificationSettings)
+            viewModel.onIntent(MainIntent.OpenNotificationSettings)
+            assertNotNull(viewModel.uiState.value.openNotificationSettings)
         }
 
     private fun createViewModel() = MainViewModel(scheduleRepository, userRepository, authRepository, settingsRepository, alarmScheduler)


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- Closes #216
- Refs #200

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
최초 진입에서 Google 로그인 Activity 직후 뜰 수 있던 자동 알림 권한 요청을 제거합니다. 메인 화면의 기존 설명과 ‘알림 설정 열기’ 버튼을 통해 사용자가 허용 시점을 선택합니다.

설정에서 돌아오면 앱·알람 채널의 현재 허용 상태를 다시 확인합니다. 허용하지 않으면 안내가 남고, 화면 진입·로그인·복귀만으로 외부 설정이 열리지 않는 회귀를 추가합니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 화면 구성과 문자열은 #207의 기존 안내·설정 버튼을 유지합니다.
- 격리 API 34에서 처음 설치 후 미요청 상태의 실제 앱 알림 설정 화면을 확인했습니다. 스위치 조작 전후 POST_NOTIFICATIONS가 false → true → false로 변경됐습니다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- main 단위 68개, app/main Android lint, 전체 ktlint, app assembleDebug 통과.
- 메인 초기 진입/로그인/복귀는 자동 설정 요청 없음, 거부 복귀는 안내 유지와 재시도 가능, 허용 복귀는 안내 해제를 확인합니다.
- 실제 API 34 확인은 새 APK 설치 후 앱을 실행하거나 런타임 권한창을 띄우기 전에 진행했습니다. 기존 설정 Intent로 허용할 수 있음을 확인했고, 검증용 에뮬레이터는 종료했습니다.
- 새 권한·의존성·팝업·요청 이력 저장은 추가하지 않습니다. 모든 OEM과 실제 제품 알람 전달 검증은 #122에서 이어갑니다.

공식 근거:
- https://developer.android.com/develop/ui/compose/notifications/notification-permission
- https://developer.android.com/reference/android/provider/Settings#ACTION_APP_NOTIFICATION_SETTINGS
